### PR TITLE
feat(web): /onboarding + /profile student-profile management

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -46,6 +46,27 @@ export async function middleware(request: NextRequest) {
     return NextResponse.redirect(redirectUrl)
   }
 
+  // If the user is authenticated but has not completed onboarding, route them through onboarding
+  // for any authenticated, non-public page. This prevents "half-set-up" sessions from drifting.
+  if (
+    session &&
+    !pathname.startsWith('/onboarding') &&
+    !pathname.startsWith('/api') &&
+    !pathname.startsWith('/auth')
+  ) {
+    const { data: profileRow, error: profileError } = await supabase
+      .from('profiles')
+      .select('onboarding_complete')
+      .eq('id', session.user.id)
+      .maybeSingle()
+
+    if (!profileError && profileRow && profileRow.onboarding_complete === false) {
+      const redirectUrl = request.nextUrl.clone()
+      redirectUrl.pathname = '/onboarding'
+      return NextResponse.redirect(redirectUrl)
+    }
+  }
+
   if ((pathname === '/login' || pathname === '/signup') && session) {
     const redirectUrl = request.nextUrl.clone()
     redirectUrl.pathname = '/dashboard'

--- a/apps/web/src/app/api/onboarding/route.ts
+++ b/apps/web/src/app/api/onboarding/route.ts
@@ -1,0 +1,134 @@
+import { NextResponse } from 'next/server'
+import { createNextServerSupabaseClient, USER_ROLES, type UserRole } from '@mysryear/shared'
+
+function badRequest(message: string) {
+  return NextResponse.json({ ok: false, error: message }, { status: 400 })
+}
+
+type OnboardingPayload = {
+  role: UserRole
+  studentProfile?: {
+    firstName?: string
+    lastName?: string
+    graduationYear?: number
+    schoolId?: string | null
+  }
+}
+
+export async function POST(req: Request) {
+  const supabase = await createNextServerSupabaseClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return NextResponse.json({ ok: false, error: 'Not authenticated' }, { status: 401 })
+  }
+
+  const json = (await req.json().catch(() => null)) as OnboardingPayload | null
+  if (!json) return badRequest('Invalid JSON')
+
+  const { role, studentProfile } = json
+  if (!USER_ROLES.includes(role)) return badRequest('Invalid role')
+
+  // Upsert role + onboarding flag immediately so middleware stops bouncing.
+  const { error: profileUpdateError } = await supabase
+    .from('profiles')
+    .update({ role, onboarding_complete: true })
+    .eq('id', session.user.id)
+
+  if (profileUpdateError) return badRequest(profileUpdateError.message)
+
+  let activeStudentProfileId: string | null = null
+
+  if (role === 'student') {
+    // Student-led: ensure a student profile exists and is linked to the auth user.
+    const { data: existing, error: existingError } = await supabase
+      .from('student_profiles')
+      .select('id')
+      .eq('student_user_id', session.user.id)
+      .maybeSingle()
+    if (existingError) return badRequest(existingError.message)
+
+    if (existing?.id) {
+      activeStudentProfileId = existing.id as string
+      const { error: updateSpError } = await supabase
+        .from('student_profiles')
+        .update({
+          first_name: studentProfile?.firstName ?? null,
+          last_name: studentProfile?.lastName ?? null,
+          graduation_year: studentProfile?.graduationYear ?? null,
+          school_id: studentProfile?.schoolId ?? null,
+        })
+        .eq('id', activeStudentProfileId)
+      if (updateSpError) return badRequest(updateSpError.message)
+    } else {
+      const { data: created, error: createError } = await supabase
+        .from('student_profiles')
+        .insert({
+          student_user_id: session.user.id,
+          created_by_user_id: session.user.id,
+          first_name: studentProfile?.firstName ?? null,
+          last_name: studentProfile?.lastName ?? null,
+          graduation_year: studentProfile?.graduationYear ?? null,
+          school_id: studentProfile?.schoolId ?? null,
+        })
+        .select('id')
+        .single()
+      if (createError) return badRequest(createError.message)
+      activeStudentProfileId = (created?.id as string) || null
+    }
+
+    if (activeStudentProfileId) {
+      // Ensure membership row exists.
+      const { error: relError } = await supabase.from('family_relationships').insert({
+        student_profile_id: activeStudentProfileId,
+        user_id: session.user.id,
+        role: 'student',
+      })
+      // Ignore conflicts (unique constraint) for idempotency.
+      if (relError && !/duplicate key/i.test(relError.message)) return badRequest(relError.message)
+    }
+  } else if (role === 'parent' || role === 'guardian') {
+    // Parent-led: create a student profile container (student can claim later).
+    const { data: created, error: createError } = await supabase
+      .from('student_profiles')
+      .insert({
+        student_user_id: null,
+        created_by_user_id: session.user.id,
+        first_name: studentProfile?.firstName ?? null,
+        last_name: studentProfile?.lastName ?? null,
+        graduation_year: studentProfile?.graduationYear ?? null,
+        school_id: studentProfile?.schoolId ?? null,
+      })
+      .select('id')
+      .single()
+    if (createError) return badRequest(createError.message)
+
+    activeStudentProfileId = (created?.id as string) || null
+
+    if (activeStudentProfileId) {
+      // For now: creators are admins so they can invite and manage relationships.
+      const { error: relError } = await supabase.from('family_relationships').insert({
+        student_profile_id: activeStudentProfileId,
+        user_id: session.user.id,
+        role: 'admin',
+      })
+      if (relError && !/duplicate key/i.test(relError.message)) return badRequest(relError.message)
+    }
+  } else if (role === 'counselor') {
+    // Counselor onboarding does not create a student profile. They will be linked via invites.
+    activeStudentProfileId = null
+  }
+
+  if (activeStudentProfileId) {
+    const { error: activeError } = await supabase
+      .from('profiles')
+      .update({ active_student_profile_id: activeStudentProfileId })
+      .eq('id', session.user.id)
+    if (activeError) return badRequest(activeError.message)
+  }
+
+  return NextResponse.json({ ok: true, role, activeStudentProfileId })
+}
+

--- a/apps/web/src/app/api/profile/active-student-profile/route.ts
+++ b/apps/web/src/app/api/profile/active-student-profile/route.ts
@@ -1,0 +1,32 @@
+import { NextResponse } from 'next/server'
+import { createNextServerSupabaseClient } from '@mysryear/shared'
+
+export async function PATCH(req: Request) {
+  const supabase = await createNextServerSupabaseClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return NextResponse.json({ ok: false, error: 'Not authenticated' }, { status: 401 })
+  }
+
+  const json = (await req.json().catch(() => null)) as { studentProfileId?: string | null } | null
+  if (!json) {
+    return NextResponse.json({ ok: false, error: 'Invalid JSON' }, { status: 400 })
+  }
+
+  const { studentProfileId } = json
+
+  const { error } = await supabase
+    .from('profiles')
+    .update({ active_student_profile_id: studentProfileId ?? null })
+    .eq('id', session.user.id)
+
+  if (error) {
+    return NextResponse.json({ ok: false, error: error.message }, { status: 400 })
+  }
+
+  return NextResponse.json({ ok: true })
+}
+

--- a/apps/web/src/app/api/profile/invites/route.ts
+++ b/apps/web/src/app/api/profile/invites/route.ts
@@ -22,7 +22,7 @@ export async function POST(req: Request) {
   if (!body) return jsonError('Invalid JSON')
 
   const studentProfileId = body.studentProfileId
-  const invitedEmail = (body.invitedEmail || '').trim()
+  const invitedEmail = (body.invitedEmail || '').trim().toLowerCase()
   const relationshipRole = body.relationshipRole
 
   if (!studentProfileId) return jsonError('Missing studentProfileId')
@@ -87,4 +87,3 @@ export async function PATCH(req: Request) {
 
   return NextResponse.json({ ok: true, invite })
 }
-

--- a/apps/web/src/app/api/profile/invites/route.ts
+++ b/apps/web/src/app/api/profile/invites/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server'
+import { createNextServerSupabaseClient } from '@mysryear/shared'
+
+function jsonError(message: string, status = 400) {
+  return NextResponse.json({ ok: false, error: message }, { status })
+}
+
+export async function POST(req: Request) {
+  const supabase = await createNextServerSupabaseClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) return jsonError('Not authenticated', 401)
+
+  const body = (await req.json().catch(() => null)) as
+    | {
+        studentProfileId?: string
+        invitedEmail?: string
+        relationshipRole?: 'parent' | 'guardian' | 'counselor'
+      }
+    | null
+  if (!body) return jsonError('Invalid JSON')
+
+  const studentProfileId = body.studentProfileId
+  const invitedEmail = (body.invitedEmail || '').trim()
+  const relationshipRole = body.relationshipRole
+
+  if (!studentProfileId) return jsonError('Missing studentProfileId')
+  if (!invitedEmail) return jsonError('Missing invitedEmail')
+  if (!relationshipRole) return jsonError('Missing relationshipRole')
+
+  const { data, error } = await supabase
+    .from('student_profile_relationship_invites')
+    .insert({
+      student_profile_id: studentProfileId,
+      invited_email: invitedEmail,
+      relationship_role: relationshipRole,
+      status: 'pending',
+      created_by_user_id: session.user.id,
+    })
+    .select('*')
+    .single()
+
+  if (error) return jsonError(error.message)
+  return NextResponse.json({ ok: true, invite: data })
+}
+
+export async function PATCH(req: Request) {
+  const supabase = await createNextServerSupabaseClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) return jsonError('Not authenticated', 401)
+
+  const body = (await req.json().catch(() => null)) as
+    | {
+        inviteId?: string
+        action?: 'accept' | 'decline'
+      }
+    | null
+  if (!body) return jsonError('Invalid JSON')
+
+  const inviteId = body.inviteId
+  const action = body.action
+  if (!inviteId) return jsonError('Missing inviteId')
+  if (!action) return jsonError('Missing action')
+
+  const nextStatus = action === 'accept' ? 'accepted' : 'declined'
+
+  const { data: invite, error: updateError } = await supabase
+    .from('student_profile_relationship_invites')
+    .update({ status: nextStatus, invited_user_id: session.user.id })
+    .eq('id', inviteId)
+    .select('*')
+    .single()
+
+  if (updateError) return jsonError(updateError.message)
+
+  if (action === 'accept') {
+    const { error: relError } = await supabase.from('family_relationships').insert({
+      student_profile_id: invite.student_profile_id,
+      user_id: session.user.id,
+      role: invite.relationship_role,
+    })
+    if (relError && !/duplicate key/i.test(relError.message)) return jsonError(relError.message)
+  }
+
+  return NextResponse.json({ ok: true, invite })
+}
+

--- a/apps/web/src/app/onboarding/page.tsx
+++ b/apps/web/src/app/onboarding/page.tsx
@@ -1,0 +1,50 @@
+import { requireSessionProfile } from '@/lib/auth'
+import { createNextServerSupabaseClient, type UserRole } from '@mysryear/shared'
+import { redirect } from 'next/navigation'
+import OnboardingForm from './ui/OnboardingForm'
+
+export default async function OnboardingPage() {
+  const sp = await requireSessionProfile('/onboarding')
+  const supabase = await createNextServerSupabaseClient()
+
+  const { data: profileRow, error: profileError } = await supabase
+    .from('profiles')
+    .select('role,onboarding_complete')
+    .eq('id', sp.user.id)
+    .maybeSingle()
+
+  if (profileError) {
+    throw profileError
+  }
+
+  if (profileRow?.onboarding_complete) {
+    redirect('/dashboard')
+  }
+
+  const { data: schools } = await supabase
+    .from('schools')
+    .select('id,name,city,state')
+    .order('name', { ascending: true })
+    .limit(5000)
+
+  return (
+    <section className="container-prose pt-10 pb-20">
+      <div className="card p-8">
+        <div className="badge">First-time setup</div>
+        <h1 className="mt-3 text-3xl sm:text-4xl font-black tracking-tight">Onboarding</h1>
+        <p className="mt-3 text-slate-700 max-w-2xl">
+          Tell us who you are and who you’re planning for. MySRYear is built for students and the
+          trusted adults who support them.
+        </p>
+
+        <div className="mt-8">
+          <OnboardingForm
+            defaultRole={(profileRow?.role as UserRole | undefined) || 'student'}
+            schools={(schools || []) as { id: string; name: string; city: string | null; state: string | null }[]}
+          />
+        </div>
+      </div>
+    </section>
+  )
+}
+

--- a/apps/web/src/app/onboarding/ui/OnboardingForm.tsx
+++ b/apps/web/src/app/onboarding/ui/OnboardingForm.tsx
@@ -1,0 +1,192 @@
+'use client'
+
+import { USER_ROLES, type UserRole } from '@mysryear/shared'
+import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+type School = { id: string; name: string; city: string | null; state: string | null }
+
+export default function OnboardingForm({
+  defaultRole,
+  schools,
+}: {
+  defaultRole: UserRole
+  schools: School[]
+}) {
+  const router = useRouter()
+  const [role, setRole] = useState<UserRole>(defaultRole)
+  const [firstName, setFirstName] = useState('')
+  const [lastName, setLastName] = useState('')
+  const [graduationYear, setGraduationYear] = useState<number | ''>('')
+  const [schoolQuery, setSchoolQuery] = useState('')
+  const [schoolId, setSchoolId] = useState<string | null>(null)
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const filteredSchools = useMemo(() => {
+    const q = schoolQuery.trim().toLowerCase()
+    if (!q) return schools.slice(0, 50)
+    return schools
+      .filter((s) => s.name.toLowerCase().includes(q))
+      .slice(0, 50)
+  }, [schoolQuery, schools])
+
+  const needsStudentProfile = role === 'student' || role === 'parent' || role === 'guardian'
+
+  const canSubmit = !loading && USER_ROLES.includes(role) && (!needsStudentProfile || Boolean(graduationYear))
+
+  async function submit() {
+    setLoading(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/onboarding', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          role,
+          studentProfile: needsStudentProfile
+            ? {
+                firstName: firstName || undefined,
+                lastName: lastName || undefined,
+                graduationYear: typeof graduationYear === 'number' ? graduationYear : undefined,
+                schoolId,
+              }
+            : undefined,
+        }),
+      })
+
+      const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null
+      if (!res.ok || !json?.ok) {
+        setError(json?.error || 'Onboarding failed')
+        return
+      }
+
+      router.push('/dashboard')
+      router.refresh()
+    } catch {
+      setError('Onboarding failed')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="grid sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-semibold text-slate-700 mb-2">Account type</label>
+          <select
+            className="input w-full px-4 py-3 rounded-lg"
+            value={role}
+            onChange={(e) => setRole(e.target.value as UserRole)}
+          >
+            <option value="student">Student</option>
+            <option value="parent">Parent</option>
+            <option value="guardian">Guardian</option>
+            <option value="counselor">Counselor</option>
+          </select>
+          <p className="mt-2 text-xs text-slate-600">
+            Counselors are currently read/support access only by invitation.
+          </p>
+        </div>
+      </div>
+
+      {needsStudentProfile && (
+        <div className="space-y-4">
+          <div className="grid sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-semibold text-slate-700 mb-2">Student first name</label>
+              <input
+                className="input w-full px-4 py-3 rounded-lg"
+                value={firstName}
+                onChange={(e) => setFirstName(e.target.value)}
+                placeholder="First name"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-semibold text-slate-700 mb-2">Student last name</label>
+              <input
+                className="input w-full px-4 py-3 rounded-lg"
+                value={lastName}
+                onChange={(e) => setLastName(e.target.value)}
+                placeholder="Last name"
+              />
+            </div>
+          </div>
+
+          <div className="grid sm:grid-cols-2 gap-4">
+            <div>
+              <label className="block text-sm font-semibold text-slate-700 mb-2">Graduation year</label>
+              <input
+                className="input w-full px-4 py-3 rounded-lg"
+                value={graduationYear}
+                onChange={(e) => setGraduationYear(e.target.value ? Number(e.target.value) : '')}
+                placeholder="e.g. 2028"
+                inputMode="numeric"
+              />
+              <p className="mt-2 text-xs text-slate-600">Required to personalize timelines.</p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-semibold text-slate-700 mb-2">High school</label>
+              <input
+                className="input w-full px-4 py-3 rounded-lg"
+                value={schoolQuery}
+                onChange={(e) => {
+                  setSchoolQuery(e.target.value)
+                  setSchoolId(null)
+                }}
+                placeholder="Search your school"
+              />
+              <div className="mt-2 max-h-48 overflow-auto border border-slate-200 rounded-lg bg-white">
+                {filteredSchools.length === 0 ? (
+                  <div className="p-3 text-sm text-slate-600">No matches</div>
+                ) : (
+                  filteredSchools.map((s) => (
+                    <button
+                      key={s.id}
+                      type="button"
+                      className={`w-full text-left px-3 py-2 text-sm hover:bg-slate-50 ${
+                        schoolId === s.id ? 'bg-slate-50' : ''
+                      }`}
+                      onClick={() => {
+                        setSchoolId(s.id)
+                        setSchoolQuery(`${s.name}${s.city ? `, ${s.city}` : ''}${s.state ? `, ${s.state}` : ''}`)
+                      }}
+                    >
+                      <div className="font-semibold text-slate-900">{s.name}</div>
+                      <div className="text-xs text-slate-600">
+                        {[s.city, s.state].filter(Boolean).join(', ')}
+                      </div>
+                    </button>
+                  ))
+                )}
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
+      {error && (
+        <div className="text-red-600 text-sm text-center p-3 rounded-lg bg-red-50 border border-red-200">
+          {error}
+        </div>
+      )}
+
+      <div className="flex items-center gap-3">
+        <button
+          type="button"
+          className="btn-primary"
+          onClick={submit}
+          disabled={!canSubmit}
+        >
+          {loading ? 'Saving...' : 'Finish setup'}
+        </button>
+        <div className="text-xs text-slate-600">
+          You can manage profiles and relationships later in <span className="font-semibold">/profile</span>.
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -78,13 +78,12 @@ export default async function ProfilePage() {
     .order('created_at', { ascending: false })
     .limit(50)
 
-  const email = (sp.user.email || '').trim()
-  const invitedEmailFilter = email ? `,and(invited_user_id.is.null,invited_email.ilike.${email})` : ''
   const { data: invitesReceived } = await supabase
     .from('student_profile_relationship_invites')
     .select('*')
-    // Show invites linked directly to the user_id OR invites issued to this user's email before they had an account.
-    .or(`invited_user_id.eq.${sp.user.id}${invitedEmailFilter}`)
+    // Rely on RLS to only return invites meant for this user:
+    // - invited_user_id = auth.uid()
+    // - or invited_email matches auth.jwt email (for invites created before account existed)
     .order('created_at', { ascending: false })
     .limit(50)
 

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -78,10 +78,13 @@ export default async function ProfilePage() {
     .order('created_at', { ascending: false })
     .limit(50)
 
+  const email = (sp.user.email || '').trim()
+  const invitedEmailFilter = email ? `,and(invited_user_id.is.null,invited_email.ilike.${email})` : ''
   const { data: invitesReceived } = await supabase
     .from('student_profile_relationship_invites')
     .select('*')
-    .eq('invited_user_id', sp.user.id)
+    // Show invites linked directly to the user_id OR invites issued to this user's email before they had an account.
+    .or(`invited_user_id.eq.${sp.user.id}${invitedEmailFilter}`)
     .order('created_at', { ascending: false })
     .limit(50)
 

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -1,15 +1,89 @@
 import { requireSessionProfile } from '@/lib/auth'
 import { createNextServerSupabaseClient } from '@mysryear/shared'
+import ActiveStudentProfileSelector from './ui/ActiveStudentProfileSelector'
+import RelationshipInvites from './ui/RelationshipInvites'
+
+type SchoolRow = { name: string | null } | null
+type StudentProfileRow = {
+  id: string
+  first_name: string | null
+  last_name: string | null
+  graduation_year: number | null
+  school_id: string | null
+  schools: SchoolRow
+}
+
+type RelationshipRow = {
+  role: string
+  student_profile_id: string
+  student_profiles: StudentProfileRow | null
+}
+
+type InviteRow = {
+  id: string
+  student_profile_id: string
+  invited_email: string | null
+  invited_user_id: string | null
+  relationship_role: 'parent' | 'guardian' | 'counselor'
+  status: 'pending' | 'accepted' | 'declined' | 'expired'
+  created_by_user_id: string
+  created_at: string
+}
 
 export default async function ProfilePage() {
   const sp = await requireSessionProfile('/profile')
   const supabase = await createNextServerSupabaseClient()
 
-  const { data: profileRow } = await supabase
+  const { data: profileRow, error: profileError } = await supabase
     .from('profiles')
-    .select('role,onboarding_complete,state,path,testing,early_action,deadline_lead_days')
+    .select('role,onboarding_complete,state,path,testing,early_action,deadline_lead_days,active_student_profile_id')
     .eq('id', sp.user.id)
     .maybeSingle()
+
+  if (profileError) throw profileError
+
+  const { data: ownedStudentProfile } = await supabase
+    .from('student_profiles')
+    .select('id,first_name,last_name,graduation_year,school_id,schools(name)')
+    .eq('student_user_id', sp.user.id)
+    .maybeSingle()
+
+  const { data: relRows } = await supabase
+    .from('family_relationships')
+    .select('role,student_profile_id,student_profiles(id,first_name,last_name,graduation_year,school_id,schools(name))')
+    .eq('user_id', sp.user.id)
+    .order('created_at', { ascending: true })
+
+  const studentProfiles: StudentProfileRow[] = []
+  if (ownedStudentProfile?.id) studentProfiles.push(ownedStudentProfile as unknown as StudentProfileRow)
+  for (const r of (relRows || []) as unknown as RelationshipRow[]) {
+    const spRow = r.student_profiles
+    if (!spRow?.id) continue
+    if (!studentProfiles.some((x) => x.id === spRow.id)) studentProfiles.push(spRow)
+  }
+
+  const activeStudentProfileId =
+    (profileRow?.active_student_profile_id as string | null | undefined) ||
+    (ownedStudentProfile?.id as string | undefined) ||
+    studentProfiles[0]?.id ||
+    null
+
+  const activeStudentProfile =
+    studentProfiles.find((p) => p.id === activeStudentProfileId) || studentProfiles[0] || null
+
+  const { data: invitesCreated } = await supabase
+    .from('student_profile_relationship_invites')
+    .select('*')
+    .eq('created_by_user_id', sp.user.id)
+    .order('created_at', { ascending: false })
+    .limit(50)
+
+  const { data: invitesReceived } = await supabase
+    .from('student_profile_relationship_invites')
+    .select('*')
+    .eq('invited_user_id', sp.user.id)
+    .order('created_at', { ascending: false })
+    .limit(50)
 
   return (
     <section className="container-prose pt-10 pb-20 space-y-6">
@@ -17,8 +91,7 @@ export default async function ProfilePage() {
         <div className="badge">Account</div>
         <h1 className="mt-3 text-3xl sm:text-4xl font-black tracking-tight">Profile</h1>
         <p className="mt-3 text-slate-700 max-w-2xl">
-          This is your web profile view. We’ll keep this aligned with the mobile profile as the app
-          rebuild continues.
+          Manage your account, your active student profile, and linked supporters (parent/guardian/counselor).
         </p>
 
         <div className="mt-6 grid sm:grid-cols-2 gap-4">
@@ -48,19 +121,69 @@ export default async function ProfilePage() {
               <div>
                 <span className="font-semibold">Testing:</span> {profileRow?.testing || '—'}
               </div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card p-8">
+        <div className="badge">Student Profile</div>
+        <h2 className="mt-3 text-2xl font-black tracking-tight">Active Student Profile</h2>
+        <p className="mt-2 text-slate-700">
+          LifePath, uploads, and planning tools should attach to your active student profile.
+        </p>
+
+        <div className="mt-6">
+          <ActiveStudentProfileSelector
+            activeStudentProfileId={activeStudentProfileId}
+            studentProfiles={studentProfiles}
+          />
+        </div>
+
+        <div className="mt-6 grid sm:grid-cols-2 gap-4">
+          <div className="card p-4">
+            <div className="text-xs font-semibold text-slate-600">Student</div>
+            <div className="mt-1 font-black">
+              {activeStudentProfile
+                ? [activeStudentProfile.first_name, activeStudentProfile.last_name].filter(Boolean).join(' ') || '—'
+                : '—'}
+            </div>
+            <div className="mt-2 text-sm text-slate-700">
               <div>
-                <span className="font-semibold">Early Action:</span>{' '}
-                {profileRow?.early_action === null || profileRow?.early_action === undefined
-                  ? '—'
-                  : profileRow.early_action
-                    ? 'Yes'
-                    : 'No'}
+                <span className="font-semibold">Graduation year:</span>{' '}
+                {activeStudentProfile?.graduation_year || '—'}
+              </div>
+              <div>
+                <span className="font-semibold">School:</span> {activeStudentProfile?.schools?.name || '—'}
               </div>
             </div>
           </div>
+          <div className="card p-4">
+            <div className="text-xs font-semibold text-slate-600">What’s Next</div>
+            <div className="mt-2 text-sm text-slate-700 space-y-1">
+              <div>1. Invite a parent/guardian/counselor below.</div>
+              <div>2. Build LifePath in A.U.R.A.</div>
+              <div>3. Upload documents and track milestones.</div>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card p-8">
+        <div className="badge">Relationships</div>
+        <h2 className="mt-3 text-2xl font-black tracking-tight">Invites & Linked Support</h2>
+        <p className="mt-2 text-slate-700">
+          Invite supporters to help plan. Counselors are read/support access only for now.
+        </p>
+
+        <div className="mt-6">
+          <RelationshipInvites
+            activeStudentProfileId={activeStudentProfileId}
+            invitesCreated={(invitesCreated || []) as unknown as InviteRow[]}
+            invitesReceived={(invitesReceived || []) as unknown as InviteRow[]}
+          />
         </div>
       </div>
     </section>
   )
 }
-

--- a/apps/web/src/app/profile/ui/ActiveStudentProfileSelector.tsx
+++ b/apps/web/src/app/profile/ui/ActiveStudentProfileSelector.tsx
@@ -1,0 +1,78 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useState } from 'react'
+
+type StudentProfileRow = {
+  id: string
+  first_name: string | null
+  last_name: string | null
+  graduation_year: number | null
+  schools: { name: string | null } | null
+}
+
+export default function ActiveStudentProfileSelector({
+  activeStudentProfileId,
+  studentProfiles,
+}: {
+  activeStudentProfileId: string | null
+  studentProfiles: StudentProfileRow[]
+}) {
+  const router = useRouter()
+  const [saving, setSaving] = useState(false)
+
+  async function setActive(studentProfileId: string) {
+    setSaving(true)
+    try {
+      await fetch('/api/profile/active-student-profile', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ studentProfileId }),
+      })
+      router.refresh()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  if (studentProfiles.length === 0) {
+    return (
+      <div className="text-sm text-slate-700">
+        No student profiles are linked to this account yet. Complete onboarding to create one.
+      </div>
+    )
+  }
+
+  return (
+    <div className="grid sm:grid-cols-2 gap-4 items-end">
+      <div>
+        <label className="block text-sm font-semibold text-slate-700 mb-2">
+          Active student profile
+        </label>
+        <select
+          className="input w-full px-4 py-3 rounded-lg"
+          value={activeStudentProfileId || ''}
+          onChange={(e) => setActive(e.target.value)}
+          disabled={saving}
+        >
+          {studentProfiles.map((p) => {
+            const name = [p.first_name, p.last_name].filter(Boolean).join(' ') || 'Student'
+            const meta = [p.graduation_year ? `Class of ${p.graduation_year}` : null, p.schools?.name || null]
+              .filter(Boolean)
+              .join(' • ')
+            return (
+              <option key={p.id} value={p.id}>
+                {name}
+                {meta ? ` — ${meta}` : ''}
+              </option>
+            )
+          })}
+        </select>
+        <p className="mt-2 text-xs text-slate-600">
+          This selection controls which student’s LifePath, uploads, and planning data you’re viewing.
+        </p>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/web/src/app/profile/ui/RelationshipInvites.tsx
+++ b/apps/web/src/app/profile/ui/RelationshipInvites.tsx
@@ -1,0 +1,181 @@
+'use client'
+
+import { useRouter } from 'next/navigation'
+import { useMemo, useState } from 'react'
+
+type InviteRow = {
+  id: string
+  student_profile_id: string
+  invited_email: string | null
+  relationship_role: 'parent' | 'guardian' | 'counselor'
+  status: 'pending' | 'accepted' | 'declined' | 'expired'
+  created_at: string
+}
+
+export default function RelationshipInvites({
+  activeStudentProfileId,
+  invitesCreated,
+  invitesReceived,
+}: {
+  activeStudentProfileId: string | null
+  invitesCreated: InviteRow[]
+  invitesReceived: InviteRow[]
+}) {
+  const router = useRouter()
+  const [email, setEmail] = useState('')
+  const [relationshipRole, setRelationshipRole] = useState<'parent' | 'guardian' | 'counselor'>('parent')
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const created = useMemo(() => invitesCreated || [], [invitesCreated])
+  const received = useMemo(() => invitesReceived || [], [invitesReceived])
+
+  async function createInvite() {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/profile/invites', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          studentProfileId: activeStudentProfileId,
+          invitedEmail: email,
+          relationshipRole,
+        }),
+      })
+      const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null
+      if (!res.ok || !json?.ok) {
+        setError(json?.error || 'Invite failed')
+        return
+      }
+      setEmail('')
+      router.refresh()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function act(inviteId: string, action: 'accept' | 'decline') {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/profile/invites', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ inviteId, action }),
+      })
+      const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null
+      if (!res.ok || !json?.ok) {
+        setError(json?.error || 'Action failed')
+        return
+      }
+      router.refresh()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="space-y-6">
+      <div className="card p-4">
+        <div className="text-sm font-black">Invite a supporter</div>
+        <p className="mt-1 text-sm text-slate-700">
+          Invite a parent/guardian/counselor by email. They’ll see the invite after they create an account.
+        </p>
+
+        <div className="mt-4 grid sm:grid-cols-3 gap-3 items-end">
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-semibold text-slate-700 mb-2">Email</label>
+            <input
+              className="input w-full px-4 py-3 rounded-lg"
+              value={email}
+              onChange={(e) => setEmail(e.target.value)}
+              placeholder="parent@example.com"
+              disabled={saving}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-semibold text-slate-700 mb-2">Role</label>
+            <select
+              className="input w-full px-4 py-3 rounded-lg"
+              value={relationshipRole}
+              onChange={(e) => setRelationshipRole(e.target.value as 'parent' | 'guardian' | 'counselor')}
+              disabled={saving}
+            >
+              <option value="parent">Parent</option>
+              <option value="guardian">Guardian</option>
+              <option value="counselor">Counselor (read/support)</option>
+            </select>
+          </div>
+        </div>
+
+        {error && (
+          <div className="mt-4 text-red-600 text-sm text-center p-3 rounded-lg bg-red-50 border border-red-200">
+            {error}
+          </div>
+        )}
+
+        <div className="mt-4">
+          <button
+            type="button"
+            className="btn-primary"
+            disabled={!activeStudentProfileId || saving || !email.trim()}
+            onClick={createInvite}
+          >
+            {saving ? 'Saving...' : 'Send invite'}
+          </button>
+        </div>
+      </div>
+
+      <div className="grid sm:grid-cols-2 gap-4">
+        <div className="card p-4">
+          <div className="text-sm font-black">Invites you sent</div>
+          <div className="mt-3 space-y-2">
+            {created.length === 0 ? (
+              <div className="text-sm text-slate-600">No invites yet.</div>
+            ) : (
+              created.map((i) => (
+                <div key={i.id} className="flex items-center justify-between gap-3 border border-slate-200 rounded-lg p-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold truncate">{i.invited_email || '—'}</div>
+                    <div className="text-xs text-slate-600">
+                      {i.relationship_role} • {i.status}
+                    </div>
+                  </div>
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+
+        <div className="card p-4">
+          <div className="text-sm font-black">Invites for you</div>
+          <div className="mt-3 space-y-2">
+            {received.length === 0 ? (
+              <div className="text-sm text-slate-600">No invites yet.</div>
+            ) : (
+              received.map((i) => (
+                <div key={i.id} className="flex items-center justify-between gap-3 border border-slate-200 rounded-lg p-3">
+                  <div className="min-w-0">
+                    <div className="text-sm font-semibold truncate">{i.relationship_role}</div>
+                    <div className="text-xs text-slate-600">{i.status}</div>
+                  </div>
+                  {i.status === 'pending' ? (
+                    <div className="flex items-center gap-2">
+                      <button className="btn-secondary" disabled={saving} onClick={() => act(i.id, 'decline')}>
+                        Decline
+                      </button>
+                      <button className="btn-primary" disabled={saving} onClick={() => act(i.id, 'accept')}>
+                        Accept
+                      </button>
+                    </div>
+                  ) : null}
+                </div>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -104,6 +104,7 @@ export default function Signup() {
               >
                 <option value="student">Student</option>
                 <option value="parent">Parent</option>
+                <option value="guardian">Guardian</option>
                 <option value="counselor">Counselor</option>
               </select>
             </div>

--- a/apps/web/src/lib/student-profile.ts
+++ b/apps/web/src/lib/student-profile.ts
@@ -13,7 +13,7 @@ export async function getActiveStudentProfileId(): Promise<string | null> {
 
   const { data: profile, error: profileError } = await supabase
     .from('profiles')
-    .select('role')
+    .select('role,active_student_profile_id')
     .eq('id', session.user.id)
     .maybeSingle()
 
@@ -21,6 +21,10 @@ export async function getActiveStudentProfileId(): Promise<string | null> {
   if (profileError) return null
 
   const role = (profile?.role as UserRole | undefined) || 'student'
+
+  // Preferred: explicit user-selected active student profile.
+  const explicitActive = (profile?.active_student_profile_id as string | undefined) || null
+  if (explicitActive) return explicitActive
 
   if (role === 'student') {
     const { data: existing, error: existingError } = await supabase
@@ -61,4 +65,17 @@ export async function getActiveStudentProfileId(): Promise<string | null> {
 
   if (relError) return null
   return (rel?.student_profile_id as string | undefined) || null
+}
+
+export async function setActiveStudentProfileId(studentProfileId: string | null): Promise<void> {
+  const supabase = await createNextServerSupabaseClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) return
+
+  await supabase
+    .from('profiles')
+    .update({ active_student_profile_id: studentProfileId })
+    .eq('id', session.user.id)
 }

--- a/packages/shared/src/types/roles.ts
+++ b/packages/shared/src/types/roles.ts
@@ -1,3 +1,4 @@
-export const USER_ROLES = ['student', 'parent', 'counselor'] as const
+// Canonical role set for the rebuild. Keep this aligned with docs/identity-model.md.
+export const USER_ROLES = ['student', 'parent', 'guardian', 'counselor'] as const
 
 export type UserRole = (typeof USER_ROLES)[number]

--- a/supabase/migrations/20260513100000_family_student_ownership.sql
+++ b/supabase/migrations/20260513100000_family_student_ownership.sql
@@ -44,6 +44,28 @@ create table if not exists public.family_relationships (
 
 alter table public.family_relationships enable row level security;
 
+-- Helper used in RLS policies to avoid mutual-recursion between student_profiles <-> family_relationships.
+-- Runs as table owner (SQL editor migration context) and bypasses RLS by default.
+create or replace function public.is_student_profile_member(p_student_profile_id uuid)
+returns boolean
+language sql
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1
+    from public.student_profiles sp
+    where sp.id = p_student_profile_id
+      and (sp.student_user_id = auth.uid() or sp.created_by_user_id = auth.uid())
+  )
+  or exists (
+    select 1
+    from public.family_relationships fr
+    where fr.student_profile_id = p_student_profile_id
+      and fr.user_id = auth.uid()
+  );
+$$;
+
 -- Student profile policies (defined after family_relationships exists)
 do $$
 begin
@@ -57,12 +79,7 @@ begin
     on public.student_profiles for select
     using (
       student_user_id = auth.uid()
-      or exists (
-        select 1
-        from public.family_relationships fr
-        where fr.student_profile_id = student_profiles.id
-          and fr.user_id = auth.uid()
-      )
+      or public.is_student_profile_member(student_profiles.id)
     );
   end if;
 end $$;
@@ -119,12 +136,7 @@ begin
       user_id = auth.uid()
       -- Allow the student (student_user_id) and the profile creator (created_by_user_id)
       -- to list all relationships for that student profile.
-      or exists (
-        select 1
-        from public.student_profiles sp
-        where sp.id = family_relationships.student_profile_id
-          and (sp.student_user_id = auth.uid() or sp.created_by_user_id = auth.uid())
-      )
+      or public.is_student_profile_member(family_relationships.student_profile_id)
     );
   end if;
 end $$;

--- a/supabase/migrations/20260513100000_family_student_ownership.sql
+++ b/supabase/migrations/20260513100000_family_student_ownership.sql
@@ -115,12 +115,15 @@ begin
     create policy family_relationships_select_member
     on public.family_relationships for select
     using (
+      -- Always allow a user to see their own relationship rows.
       user_id = auth.uid()
+      -- Allow the student (student_user_id) and the profile creator (created_by_user_id)
+      -- to list all relationships for that student profile.
       or exists (
         select 1
-        from public.family_relationships fr2
-        where fr2.student_profile_id = family_relationships.student_profile_id
-          and fr2.user_id = auth.uid()
+        from public.student_profiles sp
+        where sp.id = family_relationships.student_profile_id
+          and (sp.student_user_id = auth.uid() or sp.created_by_user_id = auth.uid())
       )
     );
   end if;

--- a/supabase/migrations/20260513120000_identity_onboarding_tables.sql
+++ b/supabase/migrations/20260513120000_identity_onboarding_tables.sql
@@ -61,6 +61,31 @@ alter table public.family_relationships
 -- - creators can add themselves as admin on profiles they created
 -- - invites will be handled by invite-specific policy below
 drop policy if exists family_relationships_insert_self on public.family_relationships;
+drop policy if exists family_relationships_select_member on public.family_relationships;
+
+-- NOTE: We re-create the SELECT policy here to avoid RLS recursion.
+-- Never reference `family_relationships` within its own RLS policy expressions.
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'family_relationships'
+      and policyname = 'family_relationships_select_member'
+  ) then
+    create policy family_relationships_select_member
+    on public.family_relationships for select
+    using (
+      user_id = auth.uid()
+      or exists (
+        select 1
+        from public.student_profiles sp
+        where sp.id = family_relationships.student_profile_id
+          and (sp.student_user_id = auth.uid() or sp.created_by_user_id = auth.uid())
+      )
+    );
+  end if;
+end $$;
 
 do $$
 begin

--- a/supabase/migrations/20260513120000_identity_onboarding_tables.sql
+++ b/supabase/migrations/20260513120000_identity_onboarding_tables.sql
@@ -77,12 +77,7 @@ begin
     on public.family_relationships for select
     using (
       user_id = auth.uid()
-      or exists (
-        select 1
-        from public.student_profiles sp
-        where sp.id = family_relationships.student_profile_id
-          and (sp.student_user_id = auth.uid() or sp.created_by_user_id = auth.uid())
-      )
+      or public.is_student_profile_member(family_relationships.student_profile_id)
     );
   end if;
 end $$;

--- a/supabase/migrations/20260513201500_profiles_active_student_profile.sql
+++ b/supabase/migrations/20260513201500_profiles_active_student_profile.sql
@@ -1,0 +1,18 @@
+-- Add active student profile selection to profiles (additive).
+-- This supports parent-led accounts managing multiple students and consistent container selection.
+
+alter table public.profiles
+  add column if not exists active_student_profile_id uuid references public.student_profiles(id) on delete set null;
+
+-- Best-effort backfill for existing users (safe to skip if no relationships exist).
+-- Note: this runs under admin context when applied via SQL editor.
+update public.profiles p
+set active_student_profile_id = (
+  select fr.student_profile_id
+  from public.family_relationships fr
+  where fr.user_id = p.id
+  order by fr.created_at asc
+  limit 1
+)
+where p.active_student_profile_id is null;
+


### PR DESCRIPTION
Implements the web onboarding + profile management hub per identity model.

What changed:
- Added /onboarding for first-time setup (role selection + student profile creation)
- Kept /profile as ongoing management hub
- Added active student profile selector on /profile
- Added relationship invite send/accept/decline endpoints + basic UI on /profile
- Middleware now routes authenticated but non-onboarded users to /onboarding (excludes /api and /auth)

Schema / migration:
- Adds supabase/migrations/20260513201500_profiles_active_student_profile.sql (profiles.active_student_profile_id)

Notes:
- Parent/guardian-created student profiles link creator as family_relationships.role='admin' (so they can invite/manage). This matches current RLS.
- Counselors remain read/support access only (no profile edits by default).

Manual step after merge:
- Run migration: supabase/migrations/20260513201500_profiles_active_student_profile.sql

Smoke tests:
- New user: login -> /onboarding -> finish -> /dashboard
- Returning user (onboarding_complete=true) can visit /onboarding and is redirected to /dashboard
- /profile shows active student profile selector and can switch active student
- Invite create shows in 'Invites you sent'; accepting invite links via family_relationships