### PR TITLE
fix(auth): collect onboarding fields at signup + bootstrap after email verify

### DIFF
--- a/apps/web/src/app/api/bootstrap/route.ts
+++ b/apps/web/src/app/api/bootstrap/route.ts
@@ -1,0 +1,97 @@
+import { NextResponse } from 'next/server'
+import { createNextServerSupabaseClient, USER_ROLES, type UserRole } from '@mysryear/shared'
+
+function badRequest(message: string) {
+  return NextResponse.json({ ok: false, error: message }, { status: 400 })
+}
+
+export async function POST() {
+  const supabase = await createNextServerSupabaseClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+
+  if (!session) {
+    return NextResponse.json({ ok: false, error: 'Not authenticated' }, { status: 401 })
+  }
+
+  // If onboarding is already complete, no-op.
+  const { data: profileRow } = await supabase
+    .from('profiles')
+    .select('role,onboarding_complete')
+    .eq('id', session.user.id)
+    .maybeSingle()
+
+  if (profileRow?.onboarding_complete) {
+    return NextResponse.json({ ok: true, skipped: true })
+  }
+
+  const md = (session.user.user_metadata || {}) as Record<string, unknown>
+  const role = md.role as UserRole | undefined
+  if (!role || !USER_ROLES.includes(role)) {
+    return badRequest('Missing role metadata; please complete onboarding.')
+  }
+
+  const graduationYear = typeof md.graduation_year === 'number' ? md.graduation_year : null
+  const schoolId = typeof md.school_id === 'string' ? md.school_id : null
+
+  // Use the existing onboarding endpoint logic by doing the minimal inline work here.
+  const { error: profileUpdateError } = await supabase
+    .from('profiles')
+    .update({ role, onboarding_complete: true })
+    .eq('id', session.user.id)
+
+  if (profileUpdateError) return badRequest(profileUpdateError.message)
+
+  if (role === 'student') {
+    if (!graduationYear || !schoolId) {
+      // Mark onboarding incomplete again so the UI can collect missing fields.
+      await supabase.from('profiles').update({ onboarding_complete: false }).eq('id', session.user.id)
+      return badRequest('Missing graduation year or school; please complete onboarding.')
+    }
+
+    // Ensure a student profile exists and is linked to the auth user.
+    const { data: existing } = await supabase
+      .from('student_profiles')
+      .select('id')
+      .eq('student_user_id', session.user.id)
+      .maybeSingle()
+
+    let studentProfileId: string | null = (existing?.id as string | undefined) || null
+
+    if (!studentProfileId) {
+      const { data: created, error: createError } = await supabase
+        .from('student_profiles')
+        .insert({
+          student_user_id: session.user.id,
+          created_by_user_id: session.user.id,
+          graduation_year: graduationYear,
+          school_id: schoolId,
+        })
+        .select('id')
+        .single()
+      if (createError) return badRequest(createError.message)
+      studentProfileId = (created?.id as string) || null
+    } else {
+      await supabase
+        .from('student_profiles')
+        .update({ graduation_year: graduationYear, school_id: schoolId })
+        .eq('id', studentProfileId)
+    }
+
+    if (studentProfileId) {
+      await supabase.from('family_relationships').insert({
+        student_profile_id: studentProfileId,
+        user_id: session.user.id,
+        role: 'student',
+      })
+      await supabase
+        .from('profiles')
+        .update({ active_student_profile_id: studentProfileId })
+        .eq('id', session.user.id)
+    }
+  }
+
+  return NextResponse.json({ ok: true, role })
+}
+

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -4,8 +4,29 @@ import Link from 'next/link'
 import { GraduationCap, CalendarClock, ClipboardList, FileText } from 'lucide-react'
 import StatTile from '@/components/StatTile'
 import DocUpload from '@/components/DocUpload'
+import { useAuthSession } from '@/lib/use-auth-session'
+import { useEffect } from 'react'
+import { useRouter } from 'next/navigation'
 
 export default function Dashboard() {
+  const router = useRouter()
+  const { isAuthenticated } = useAuthSession()
+
+  useEffect(() => {
+    if (!isAuthenticated) return
+    // Ensure first-time users land in a fully initialized state even if email-confirm redirects
+    // bypass middleware session detection (common with verify links).
+    fetch('/api/bootstrap', { method: 'POST' }).then(async (res) => {
+      if (res.ok) return
+      const json = (await res.json().catch(() => null)) as { error?: string } | null
+      // If bootstrap cannot complete from metadata, send user to /onboarding to finish.
+      if (json?.error) {
+        router.push('/onboarding')
+        router.refresh()
+      }
+    })
+  }, [isAuthenticated, router])
+
   const upcomingDates = [
     { date: 'Oct 15', event: 'FAFSA opens' },
     { date: 'Nov 1', event: 'Early Action deadline' },

--- a/apps/web/src/app/signup/page.tsx
+++ b/apps/web/src/app/signup/page.tsx
@@ -1,14 +1,46 @@
 'use client'
 
-import React, { useState } from 'react'
+import React, { useEffect, useMemo, useState } from 'react'
 import { createWebSupabaseClient } from '@mysryear/shared'
+import { USER_ROLES, type UserRole } from '@mysryear/shared'
 
 export default function Signup() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
+  const [role, setRole] = useState<UserRole>('student')
+  const [graduationYear, setGraduationYear] = useState<number | ''>('')
+  const [schoolId, setSchoolId] = useState<string>('')
+  const [schoolQuery, setSchoolQuery] = useState('')
+  const [schools, setSchools] = useState<
+    { id: string; name: string; city: string | null; state: string | null }[]
+  >([])
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [message, setMessage] = useState('')
+
+  useEffect(() => {
+    // Schools are public-readable by design (RLS allows select all).
+    const supabase = createWebSupabaseClient()
+    const load = async () => {
+      try {
+        const { data } = await supabase
+          .from('schools')
+          .select('id,name,city,state')
+          .order('name', { ascending: true })
+          .limit(5000)
+        if (data) setSchools(data)
+      } catch {
+        // ignore
+      }
+    }
+    void load()
+  }, [])
+
+  const filteredSchools = useMemo(() => {
+    const q = schoolQuery.trim().toLowerCase()
+    if (!q) return schools.slice(0, 50)
+    return schools.filter((s) => s.name.toLowerCase().includes(q)).slice(0, 50)
+  }, [schoolQuery, schools])
 
   const handleSignup = async (e: React.FormEvent) => {
     e.preventDefault()
@@ -17,10 +49,28 @@ export default function Signup() {
     setMessage('')
 
     try {
+      if (role === 'student') {
+        if (typeof graduationYear !== 'number' || !graduationYear) {
+          setError('Please enter your graduation year.')
+          return
+        }
+        if (!schoolId) {
+          setError('Please select your high school from the list.')
+          return
+        }
+      }
+
       const supabase = createWebSupabaseClient()
       const { data, error } = await supabase.auth.signUp({
         email,
         password,
+        options: {
+          data: {
+            role,
+            graduation_year: typeof graduationYear === 'number' ? graduationYear : null,
+            school_id: schoolId || null,
+          },
+        },
       })
 
       if (error) {
@@ -85,11 +135,93 @@ export default function Signup() {
               />
             </div>
             <div>
-              <div className="rounded-xl border border-white/10 bg-white/5 p-4 text-sm text-gray-200">
-                You’ll choose your account type (Student/Parent/Guardian/Counselor) and set up your
-                student profile in the onboarding step after you verify your email.
-              </div>
+              <label htmlFor="role" className="block text-sm font-medium text-gray-300 mb-2">
+                Account type
+              </label>
+              <select
+                id="role"
+                name="role"
+                className="input w-full px-4 py-3 rounded-lg"
+                value={role}
+                onChange={(e) => setRole(e.target.value as UserRole)}
+              >
+                {USER_ROLES.map((r) => (
+                  <option key={r} value={r}>
+                    {r}
+                  </option>
+                ))}
+              </select>
             </div>
+
+            {role === 'student' && (
+              <>
+                <div>
+                  <label
+                    htmlFor="graduationYear"
+                    className="block text-sm font-medium text-gray-300 mb-2"
+                  >
+                    Graduation year
+                  </label>
+                  <input
+                    id="graduationYear"
+                    name="graduationYear"
+                    className="input w-full px-4 py-3 rounded-lg"
+                    value={graduationYear}
+                    onChange={(e) => setGraduationYear(e.target.value ? Number(e.target.value) : '')}
+                    placeholder="e.g. 2030"
+                    inputMode="numeric"
+                    required
+                  />
+                </div>
+
+                <div>
+                  <label
+                    htmlFor="school"
+                    className="block text-sm font-medium text-gray-300 mb-2"
+                  >
+                    High school
+                  </label>
+                  <input
+                    id="school"
+                    name="school"
+                    className="input w-full px-4 py-3 rounded-lg"
+                    value={schoolQuery}
+                    onChange={(e) => {
+                      setSchoolQuery(e.target.value)
+                      setSchoolId('')
+                    }}
+                    placeholder="Search your school"
+                    required
+                  />
+                  <div className="mt-2 max-h-48 overflow-auto border border-white/10 rounded-lg bg-black/20">
+                    {filteredSchools.length === 0 ? (
+                      <div className="p-3 text-sm text-gray-300">No matches</div>
+                    ) : (
+                      filteredSchools.map((s) => (
+                        <button
+                          key={s.id}
+                          type="button"
+                          className={`w-full text-left px-3 py-2 text-sm hover:bg-white/10 ${
+                            schoolId === s.id ? 'bg-white/10' : ''
+                          }`}
+                          onClick={() => {
+                            setSchoolId(s.id)
+                            setSchoolQuery(
+                              `${s.name}${s.city ? `, ${s.city}` : ''}${s.state ? `, ${s.state}` : ''}`,
+                            )
+                          }}
+                        >
+                          <div className="font-semibold text-gray-100">{s.name}</div>
+                          <div className="text-xs text-gray-400">
+                            {[s.city, s.state].filter(Boolean).join(', ')}
+                          </div>
+                        </button>
+                      ))
+                    )}
+                  </div>
+                </div>
+              </>
+            )}
           </div>
 
           {error && (


### PR DESCRIPTION
Problem: Email confirmation redirects can bypass middleware session detection, so new users land on /dashboard without completing onboarding.

Solution:
- Signup now collects role + (for students) graduation year + high school selection and stores them in auth user metadata.
- Added POST /api/bootstrap which, on first authenticated page load, uses session.user.user_metadata to:
  - set profiles.role
  - create/link student_profiles + family_relationships
  - set profiles.active_student_profile_id
  - mark onboarding_complete=true
  - falls back to /onboarding if metadata is incomplete
- Dashboard calls /api/bootstrap on mount to ensure first-time users are initialized even if verify-link bypasses middleware.

This gets us launch-ready without relying on email-confirm redirect behavior.
