### PR TITLE
fix(auth): stop onboarding loop; let dashboard bootstrap complete setup

### DIFF
--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -51,6 +51,7 @@ export async function middleware(request: NextRequest) {
   if (
     session &&
     !pathname.startsWith('/onboarding') &&
+    pathname !== '/dashboard' &&
     !pathname.startsWith('/api') &&
     !pathname.startsWith('/auth')
   ) {
@@ -65,7 +66,9 @@ export async function middleware(request: NextRequest) {
     // Worst-case this sends the user to onboarding where we can surface a clearer error.
     if (profileError || !profileRow || profileRow.onboarding_complete === false) {
       const redirectUrl = request.nextUrl.clone()
-      redirectUrl.pathname = '/onboarding'
+      // Prefer /dashboard for first-time initialization: dashboard runs /api/bootstrap on mount,
+      // which can complete setup from auth metadata even when middleware can't yet see everything.
+      redirectUrl.pathname = '/dashboard'
       return NextResponse.redirect(redirectUrl)
     }
   }

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -5,12 +5,13 @@ import { GraduationCap, CalendarClock, ClipboardList, FileText } from 'lucide-re
 import StatTile from '@/components/StatTile'
 import DocUpload from '@/components/DocUpload'
 import { useAuthSession } from '@/lib/use-auth-session'
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
 
 export default function Dashboard() {
   const router = useRouter()
   const { isAuthenticated } = useAuthSession()
+  const [bootstrapError, setBootstrapError] = useState<string | null>(null)
 
   useEffect(() => {
     if (!isAuthenticated) return
@@ -19,11 +20,7 @@ export default function Dashboard() {
     fetch('/api/bootstrap', { method: 'POST' }).then(async (res) => {
       if (res.ok) return
       const json = (await res.json().catch(() => null)) as { error?: string } | null
-      // If bootstrap cannot complete from metadata, send user to /onboarding to finish.
-      if (json?.error) {
-        router.push('/onboarding')
-        router.refresh()
-      }
+      if (json?.error) setBootstrapError(json.error)
     })
   }, [isAuthenticated, router])
 
@@ -42,6 +39,18 @@ export default function Dashboard() {
           <p className="text-slate-700 mt-2">Your senior year, organized and stress-less</p>
         </div>
       </div>
+
+      {bootstrapError && (
+        <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          <div className="font-semibold">Finish setup</div>
+          <div className="mt-1">{bootstrapError}</div>
+          <div className="mt-3">
+            <Link href="/onboarding" className="btn-secondary inline-flex">
+              Continue Setup
+            </Link>
+          </div>
+        </div>
+      )}
 
       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6 mb-8">
         <StatTile

--- a/apps/web/tsconfig.json
+++ b/apps/web/tsconfig.json
@@ -7,9 +7,19 @@
       }
     ],
     "paths": {
-      "@/*": ["./src/*"]
+      "@/*": [
+        "./src/*"
+      ]
     }
   },
-  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
-  "exclude": ["node_modules"]
+  "include": [
+    "**/*.ts",
+    "**/*.tsx",
+    "next-env.d.ts",
+    ".next/types/**/*.ts"
+  ],
+  "exclude": [
+    "node_modules",
+    ".next"
+  ]
 }


### PR DESCRIPTION
Fixes production issue where users are being forced into /onboarding even though signup now collects full setup metadata.

Changes:
- middleware: if onboarding is incomplete/unknown, redirect to /dashboard (not /onboarding) for any non-dashboard route
- dashboard: shows a clear 'Finish setup' banner with link to /onboarding if /api/bootstrap reports missing metadata, instead of hard redirecting
- apps/web/tsconfig.json: exclude .next to avoid stale type artifacts breaking tsc

This ensures first-time sessions can be initialized via /api/bootstrap even when email verify link bypasses middleware session detection.