### PR TITLE
feat(profile): student claim invites

### DIFF
--- a/apps/web/src/app/api/profile/invites/route.ts
+++ b/apps/web/src/app/api/profile/invites/route.ts
@@ -16,7 +16,7 @@ export async function POST(req: Request) {
     | {
         studentProfileId?: string
         invitedEmail?: string
-        relationshipRole?: 'parent' | 'guardian' | 'counselor'
+        relationshipRole?: 'parent' | 'guardian' | 'counselor' | 'student'
       }
     | null
   if (!body) return jsonError('Invalid JSON')
@@ -67,6 +67,34 @@ export async function PATCH(req: Request) {
 
   const nextStatus = action === 'accept' ? 'accepted' : 'declined'
 
+  if (action === 'accept') {
+    // If this is a student-claim invite (parent-led onboarding), accept via RPC
+    // so the student can attach to the student_profiles row even when RLS would block updates.
+    const { data: inviteForType, error: inviteReadErr } = await supabase
+      .from('student_profile_relationship_invites')
+      .select('id,relationship_role')
+      .eq('id', inviteId)
+      .single()
+    if (inviteReadErr) return jsonError(inviteReadErr.message)
+
+    if (inviteForType.relationship_role === 'student') {
+      const { error: rpcErr } = await supabase.rpc('accept_student_claim_invite', {
+        p_invite_id: inviteId,
+      })
+      if (rpcErr) return jsonError(rpcErr.message)
+
+      // Return the updated invite row for UI refresh.
+      const { data: invite, error: reloadErr } = await supabase
+        .from('student_profile_relationship_invites')
+        .select('*')
+        .eq('id', inviteId)
+        .single()
+      if (reloadErr) return jsonError(reloadErr.message)
+      return NextResponse.json({ ok: true, invite })
+    }
+  }
+
+  // Default path: accept/decline supporter invites, then add family_relationships row on accept.
   const { data: invite, error: updateError } = await supabase
     .from('student_profile_relationship_invites')
     .update({ status: nextStatus, invited_user_id: session.user.id })

--- a/apps/web/src/app/api/profile/invites/route.ts
+++ b/apps/web/src/app/api/profile/invites/route.ts
@@ -44,6 +44,24 @@ export async function POST(req: Request) {
     .select('*')
     .single()
 
+  // Some environments may not yet have the `invite_type` column applied (Supabase schema cache / migration lag).
+  // Retry without the column so the core invite flow still works.
+  if (error && /invite_type.*schema cache|column .*invite_type.* does not exist/i.test(error.message)) {
+    const { data: data2, error: error2 } = await supabase
+      .from('student_profile_relationship_invites')
+      .insert({
+        student_profile_id: studentProfileId,
+        invited_email: invitedEmail,
+        relationship_role: relationshipRole,
+        status: 'pending',
+        created_by_user_id: session.user.id,
+      })
+      .select('*')
+      .single()
+    if (error2) return jsonError(error2.message)
+    return NextResponse.json({ ok: true, invite: data2 })
+  }
+
   if (error) return jsonError(error.message)
   return NextResponse.json({ ok: true, invite: data })
 }
@@ -78,7 +96,36 @@ export async function PATCH(req: Request) {
       .select('id,relationship_role,invite_type')
       .eq('id', inviteId)
       .single()
-    if (inviteReadErr) return jsonError(inviteReadErr.message)
+    if (inviteReadErr) {
+      // Back-compat: older envs without invite_type column.
+      if (/invite_type.*schema cache|column .*invite_type.* does not exist/i.test(inviteReadErr.message)) {
+        const { data: inviteForType2, error: inviteReadErr2 } = await supabase
+          .from('student_profile_relationship_invites')
+          .select('id,relationship_role')
+          .eq('id', inviteId)
+          .single()
+        if (inviteReadErr2) return jsonError(inviteReadErr2.message)
+
+        if (inviteForType2.relationship_role === 'student') {
+          const { error: rpcErr } = await supabase.rpc('accept_student_claim_invite', {
+            p_invite_id: inviteId,
+          })
+          if (rpcErr) return jsonError(rpcErr.message)
+
+          const { data: invite, error: reloadErr } = await supabase
+            .from('student_profile_relationship_invites')
+            .select('*')
+            .eq('id', inviteId)
+            .single()
+          if (reloadErr) return jsonError(reloadErr.message)
+          return NextResponse.json({ ok: true, invite })
+        }
+      } else {
+        return jsonError(inviteReadErr.message)
+      }
+    }
+
+    if (!inviteForType) return jsonError('Invite not found')
 
     if (inviteForType.relationship_role === 'student') {
       const { error: rpcErr } = await supabase.rpc('accept_student_claim_invite', {

--- a/apps/web/src/app/api/profile/invites/route.ts
+++ b/apps/web/src/app/api/profile/invites/route.ts
@@ -17,6 +17,7 @@ export async function POST(req: Request) {
         studentProfileId?: string
         invitedEmail?: string
         relationshipRole?: 'parent' | 'guardian' | 'counselor' | 'student'
+        inviteType?: 'supporter_invite' | 'access_request'
       }
     | null
   if (!body) return jsonError('Invalid JSON')
@@ -24,6 +25,7 @@ export async function POST(req: Request) {
   const studentProfileId = body.studentProfileId
   const invitedEmail = (body.invitedEmail || '').trim().toLowerCase()
   const relationshipRole = body.relationshipRole
+  const inviteType = body.inviteType || 'supporter_invite'
 
   if (!studentProfileId) return jsonError('Missing studentProfileId')
   if (!invitedEmail) return jsonError('Missing invitedEmail')
@@ -35,6 +37,7 @@ export async function POST(req: Request) {
       student_profile_id: studentProfileId,
       invited_email: invitedEmail,
       relationship_role: relationshipRole,
+      invite_type: inviteType,
       status: 'pending',
       created_by_user_id: session.user.id,
     })
@@ -72,7 +75,7 @@ export async function PATCH(req: Request) {
     // so the student can attach to the student_profiles row even when RLS would block updates.
     const { data: inviteForType, error: inviteReadErr } = await supabase
       .from('student_profile_relationship_invites')
-      .select('id,relationship_role')
+      .select('id,relationship_role,invite_type')
       .eq('id', inviteId)
       .single()
     if (inviteReadErr) return jsonError(inviteReadErr.message)
@@ -84,6 +87,21 @@ export async function PATCH(req: Request) {
       if (rpcErr) return jsonError(rpcErr.message)
 
       // Return the updated invite row for UI refresh.
+      const { data: invite, error: reloadErr } = await supabase
+        .from('student_profile_relationship_invites')
+        .select('*')
+        .eq('id', inviteId)
+        .single()
+      if (reloadErr) return jsonError(reloadErr.message)
+      return NextResponse.json({ ok: true, invite })
+    }
+
+    if (inviteForType.invite_type === 'access_request') {
+      const { error: rpcErr } = await supabase.rpc('approve_access_request', {
+        p_invite_id: inviteId,
+      })
+      if (rpcErr) return jsonError(rpcErr.message)
+
       const { data: invite, error: reloadErr } = await supabase
         .from('student_profile_relationship_invites')
         .select('*')

--- a/apps/web/src/app/api/profile/student-profile/route.ts
+++ b/apps/web/src/app/api/profile/student-profile/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from 'next/server'
+import { createNextServerSupabaseClient } from '@mysryear/shared'
+
+function jsonError(message: string, status = 400) {
+  return NextResponse.json({ ok: false, error: message }, { status })
+}
+
+export async function PATCH(req: Request) {
+  const supabase = await createNextServerSupabaseClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) return jsonError('Not authenticated', 401)
+
+  const body = (await req.json().catch(() => null)) as
+    | {
+        studentProfileId?: string
+        firstName?: string | null
+        lastName?: string | null
+        graduationYear?: number | null
+        schoolId?: string | null
+      }
+    | null
+  if (!body) return jsonError('Invalid JSON')
+
+  const studentProfileId = body.studentProfileId
+  if (!studentProfileId) return jsonError('Missing studentProfileId')
+
+  const patch: Record<string, unknown> = {}
+  if (body.firstName !== undefined) patch.first_name = body.firstName
+  if (body.lastName !== undefined) patch.last_name = body.lastName
+  if (body.graduationYear !== undefined) patch.graduation_year = body.graduationYear
+  if (body.schoolId !== undefined) patch.school_id = body.schoolId
+
+  if (Object.keys(patch).length === 0) return jsonError('No changes provided')
+
+  const { data, error } = await supabase
+    .from('student_profiles')
+    .update(patch)
+    .eq('id', studentProfileId)
+    .select('id,first_name,last_name,graduation_year,school_id')
+    .single()
+
+  if (error) return jsonError(error.message)
+  return NextResponse.json({ ok: true, studentProfile: data })
+}
+

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -3,6 +3,7 @@ import { createNextServerSupabaseClient } from '@mysryear/shared'
 import ActiveStudentProfileSelector from './ui/ActiveStudentProfileSelector'
 import RelationshipInvites from './ui/RelationshipInvites'
 import StudentProfileDetailsForm from './ui/StudentProfileDetailsForm'
+import LinkedSupporters from './ui/LinkedSupporters'
 
 type SchoolRow = { name: string | null } | null
 type StudentProfileRow = {
@@ -17,6 +18,8 @@ type StudentProfileRow = {
 type RelationshipRow = {
   role: string
   student_profile_id: string
+  user_id: string
+  created_at: string
   student_profiles: StudentProfileRow | null
 }
 
@@ -51,7 +54,9 @@ export default async function ProfilePage() {
 
   const { data: relRows } = await supabase
     .from('family_relationships')
-    .select('role,student_profile_id,student_profiles(id,first_name,last_name,graduation_year,school_id,schools(name))')
+    .select(
+      'role,user_id,student_profile_id,created_at,student_profiles(id,first_name,last_name,graduation_year,school_id,schools(name))',
+    )
     .eq('user_id', sp.user.id)
     .order('created_at', { ascending: true })
 
@@ -87,6 +92,20 @@ export default async function ProfilePage() {
     // - or invited_email matches auth.jwt email (for invites created before account existed)
     .order('created_at', { ascending: false })
     .limit(50)
+
+  // Linked supporters for the active student profile (membership rows).
+  const { data: linkedRows } = activeStudentProfileId
+    ? await supabase
+        .from('family_relationships')
+        .select('user_id,role,created_at')
+        .eq('student_profile_id', activeStudentProfileId)
+        .order('created_at', { ascending: true })
+    : { data: [] as unknown[] }
+
+  const pendingInvitesForActive =
+    (invitesCreated || []).filter(
+      (i) => i.student_profile_id === activeStudentProfileId && i.status === 'pending',
+    ) || []
 
   const { data: schools } = await supabase
     .from('schools')
@@ -195,6 +214,14 @@ export default async function ProfilePage() {
         <p className="mt-2 text-slate-700">
           Invite supporters to help plan. Counselors are read/support access only for now.
         </p>
+
+        <div className="mt-6">
+          <LinkedSupporters
+            currentUserId={sp.user.id}
+            linked={(linkedRows || []) as unknown as { user_id: string; role: string; created_at: string }[]}
+            pendingInvites={pendingInvitesForActive as unknown as { id: string; invited_email: string | null; relationship_role: string; status: string; created_at: string }[]}
+          />
+        </div>
 
         <div className="mt-6">
           <RelationshipInvites

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -2,6 +2,7 @@ import { requireSessionProfile } from '@/lib/auth'
 import { createNextServerSupabaseClient } from '@mysryear/shared'
 import ActiveStudentProfileSelector from './ui/ActiveStudentProfileSelector'
 import RelationshipInvites from './ui/RelationshipInvites'
+import StudentProfileDetailsForm from './ui/StudentProfileDetailsForm'
 
 type SchoolRow = { name: string | null } | null
 type StudentProfileRow = {
@@ -87,6 +88,12 @@ export default async function ProfilePage() {
     .order('created_at', { ascending: false })
     .limit(50)
 
+  const { data: schools } = await supabase
+    .from('schools')
+    .select('id,name,city,state')
+    .order('name', { ascending: true })
+    .limit(5000)
+
   return (
     <section className="container-prose pt-10 pb-20 space-y-6">
       <div className="card p-8">
@@ -168,6 +175,17 @@ export default async function ProfilePage() {
               <div>3. Upload documents and track milestones.</div>
             </div>
           </div>
+        </div>
+
+        <div className="mt-6">
+          <StudentProfileDetailsForm
+            studentProfileId={activeStudentProfileId}
+            initialFirstName={activeStudentProfile?.first_name || null}
+            initialLastName={activeStudentProfile?.last_name || null}
+            initialGraduationYear={activeStudentProfile?.graduation_year || null}
+            initialSchoolId={activeStudentProfile?.school_id || null}
+            schools={(schools || []) as unknown as { id: string; name: string; city: string | null; state: string | null }[]}
+          />
         </div>
       </div>
 

--- a/apps/web/src/app/profile/page.tsx
+++ b/apps/web/src/app/profile/page.tsx
@@ -24,7 +24,7 @@ type InviteRow = {
   student_profile_id: string
   invited_email: string | null
   invited_user_id: string | null
-  relationship_role: 'parent' | 'guardian' | 'counselor'
+  relationship_role: 'parent' | 'guardian' | 'counselor' | 'student'
   status: 'pending' | 'accepted' | 'declined' | 'expired'
   created_by_user_id: string
   created_at: string

--- a/apps/web/src/app/profile/ui/LinkedSupporters.tsx
+++ b/apps/web/src/app/profile/ui/LinkedSupporters.tsx
@@ -1,0 +1,104 @@
+import { ShieldCheck, UserRound } from 'lucide-react'
+
+type LinkedRelationship = {
+  user_id: string
+  role: string
+  created_at: string
+}
+
+type PendingInvite = {
+  id: string
+  invited_email: string | null
+  relationship_role: string
+  status: string
+  created_at: string
+}
+
+function shortId(id: string) {
+  if (!id) return '—'
+  return `${id.slice(0, 8)}…${id.slice(-4)}`
+}
+
+function formatRole(role: string) {
+  if (!role) return '—'
+  return role.charAt(0).toUpperCase() + role.slice(1)
+}
+
+export default function LinkedSupporters({
+  currentUserId,
+  linked,
+  pendingInvites,
+}: {
+  currentUserId: string
+  linked: LinkedRelationship[]
+  pendingInvites: PendingInvite[]
+}) {
+  return (
+    <div className="card p-6">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="badge">Relationships</div>
+          <h3 className="mt-2 text-lg font-black">Linked Supporters</h3>
+          <p className="mt-1 text-sm text-slate-700">
+            These people can access this student profile based on their role. Counselors are read/support access only.
+          </p>
+        </div>
+      </div>
+
+      <div className="mt-4 space-y-2">
+        {linked.length === 0 ? (
+          <div className="text-sm text-slate-600">No linked supporters yet.</div>
+        ) : (
+          linked.map((r) => (
+            <div
+              key={`${r.user_id}:${r.role}`}
+              className="flex items-center justify-between gap-3 border border-slate-200 rounded-lg p-3 bg-white"
+            >
+              <div className="min-w-0 flex items-center gap-3">
+                <div className="h-9 w-9 rounded-full bg-slate-100 flex items-center justify-center">
+                  <UserRound className="h-5 w-5 text-slate-600" />
+                </div>
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold truncate">
+                    {formatRole(r.role)}
+                    {r.user_id === currentUserId ? <span className="text-slate-500"> (You)</span> : null}
+                  </div>
+                  <div className="text-xs text-slate-600">User: {shortId(r.user_id)}</div>
+                </div>
+              </div>
+
+              <div className="flex items-center gap-2 text-xs text-emerald-700 bg-emerald-50 border border-emerald-200 px-2 py-1 rounded-full">
+                <ShieldCheck className="h-4 w-4" />
+                Linked
+              </div>
+            </div>
+          ))
+        )}
+      </div>
+
+      <div className="mt-6">
+        <div className="text-sm font-black">Pending invites</div>
+        <div className="mt-3 space-y-2">
+          {pendingInvites.length === 0 ? (
+            <div className="text-sm text-slate-600">No pending invites for this student profile.</div>
+          ) : (
+            pendingInvites.map((i) => (
+              <div
+                key={i.id}
+                className="flex items-center justify-between gap-3 border border-slate-200 rounded-lg p-3 bg-white"
+              >
+                <div className="min-w-0">
+                  <div className="text-sm font-semibold truncate">{i.invited_email || '—'}</div>
+                  <div className="text-xs text-slate-600">
+                    {formatRole(i.relationship_role)} • {i.status}
+                  </div>
+                </div>
+              </div>
+            ))
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/web/src/app/profile/ui/RelationshipInvites.tsx
+++ b/apps/web/src/app/profile/ui/RelationshipInvites.tsx
@@ -145,9 +145,11 @@ export default function RelationshipInvites({
             <label className="block text-sm font-semibold text-slate-700 mb-2">Email</label>
             <input
               className="input w-full px-4 py-3 rounded-lg"
+              name="invite_supporter_email"
               value={email}
               onChange={(e) => setEmail(e.target.value)}
               placeholder="parent@example.com"
+              autoComplete="email"
               disabled={saving}
             />
           </div>
@@ -198,6 +200,8 @@ export default function RelationshipInvites({
               value={studentClaimEmail}
               onChange={(e) => setStudentClaimEmail(e.target.value)}
               placeholder="student@example.com"
+              name="invite_claim_student_email"
+              autoComplete="email"
               disabled={saving}
             />
           </div>
@@ -280,6 +284,8 @@ export default function RelationshipInvites({
               value={requestStudentEmail}
               onChange={(e) => setRequestStudentEmail(e.target.value)}
               placeholder="student@example.com"
+              name="request_access_student_email"
+              autoComplete="email"
               disabled={saving}
             />
           </div>
@@ -304,6 +310,8 @@ export default function RelationshipInvites({
             value={requestStudentProfileId}
             onChange={(e) => setRequestStudentProfileId(e.target.value)}
             placeholder="Paste the student_profile_id (UUID)"
+            name="request_access_student_profile_id"
+            autoComplete="off"
             disabled={saving}
           />
           <p className="mt-2 text-xs text-slate-600">

--- a/apps/web/src/app/profile/ui/RelationshipInvites.tsx
+++ b/apps/web/src/app/profile/ui/RelationshipInvites.tsx
@@ -7,7 +7,7 @@ type InviteRow = {
   id: string
   student_profile_id: string
   invited_email: string | null
-  relationship_role: 'parent' | 'guardian' | 'counselor'
+  relationship_role: 'parent' | 'guardian' | 'counselor' | 'student'
   status: 'pending' | 'accepted' | 'declined' | 'expired'
   created_at: string
 }
@@ -24,6 +24,7 @@ export default function RelationshipInvites({
   const router = useRouter()
   const [email, setEmail] = useState('')
   const [relationshipRole, setRelationshipRole] = useState<'parent' | 'guardian' | 'counselor'>('parent')
+  const [studentClaimEmail, setStudentClaimEmail] = useState('')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -49,6 +50,31 @@ export default function RelationshipInvites({
         return
       }
       setEmail('')
+      router.refresh()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function createStudentClaimInvite() {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/profile/invites', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          studentProfileId: activeStudentProfileId,
+          invitedEmail: studentClaimEmail,
+          relationshipRole: 'student',
+        }),
+      })
+      const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null
+      if (!res.ok || !json?.ok) {
+        setError(json?.error || 'Invite failed')
+        return
+      }
+      setStudentClaimEmail('')
       router.refresh()
     } finally {
       setSaving(false)
@@ -124,6 +150,36 @@ export default function RelationshipInvites({
           >
             {saving ? 'Saving...' : 'Send invite'}
           </button>
+        </div>
+      </div>
+
+      <div className="card p-4">
+        <div className="text-sm font-black">Invite student to claim this profile</div>
+        <p className="mt-1 text-sm text-slate-700">
+          For parent-led accounts: invite your student’s email so they can claim this student profile.
+        </p>
+
+        <div className="mt-4 grid sm:grid-cols-3 gap-3 items-end">
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-semibold text-slate-700 mb-2">Student email</label>
+            <input
+              className="input w-full px-4 py-3 rounded-lg"
+              value={studentClaimEmail}
+              onChange={(e) => setStudentClaimEmail(e.target.value)}
+              placeholder="student@example.com"
+              disabled={saving}
+            />
+          </div>
+          <div className="sm:col-span-1">
+            <button
+              type="button"
+              className="btn-secondary w-full"
+              disabled={!activeStudentProfileId || saving || !studentClaimEmail.trim()}
+              onClick={createStudentClaimInvite}
+            >
+              {saving ? 'Saving...' : 'Send claim invite'}
+            </button>
+          </div>
         </div>
       </div>
 

--- a/apps/web/src/app/profile/ui/RelationshipInvites.tsx
+++ b/apps/web/src/app/profile/ui/RelationshipInvites.tsx
@@ -8,6 +8,7 @@ type InviteRow = {
   student_profile_id: string
   invited_email: string | null
   relationship_role: 'parent' | 'guardian' | 'counselor' | 'student'
+  invite_type?: 'supporter_invite' | 'access_request' | null
   status: 'pending' | 'accepted' | 'declined' | 'expired'
   created_at: string
 }
@@ -25,6 +26,9 @@ export default function RelationshipInvites({
   const [email, setEmail] = useState('')
   const [relationshipRole, setRelationshipRole] = useState<'parent' | 'guardian' | 'counselor'>('parent')
   const [studentClaimEmail, setStudentClaimEmail] = useState('')
+  const [requestStudentEmail, setRequestStudentEmail] = useState('')
+  const [requestStudentProfileId, setRequestStudentProfileId] = useState('')
+  const [requestRole, setRequestRole] = useState<'parent' | 'guardian'>('parent')
   const [saving, setSaving] = useState(false)
   const [error, setError] = useState<string | null>(null)
 
@@ -75,6 +79,33 @@ export default function RelationshipInvites({
         return
       }
       setStudentClaimEmail('')
+      router.refresh()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  async function createAccessRequest() {
+    setSaving(true)
+    setError(null)
+    try {
+      const res = await fetch('/api/profile/invites', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          studentProfileId: requestStudentProfileId,
+          invitedEmail: requestStudentEmail,
+          relationshipRole: requestRole,
+          inviteType: 'access_request',
+        }),
+      })
+      const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null
+      if (!res.ok || !json?.ok) {
+        setError(json?.error || 'Request failed')
+        return
+      }
+      setRequestStudentEmail('')
+      setRequestStudentProfileId('')
       router.refresh()
     } finally {
       setSaving(false)
@@ -213,7 +244,9 @@ export default function RelationshipInvites({
               received.map((i) => (
                 <div key={i.id} className="flex items-center justify-between gap-3 border border-slate-200 rounded-lg p-3">
                   <div className="min-w-0">
-                    <div className="text-sm font-semibold truncate">{i.relationship_role}</div>
+                    <div className="text-sm font-semibold truncate">
+                      {i.invite_type === 'access_request' ? 'Access request' : 'Invite'}: {i.relationship_role}
+                    </div>
                     <div className="text-xs text-slate-600">{i.status}</div>
                   </div>
                   {i.status === 'pending' ? (
@@ -230,6 +263,63 @@ export default function RelationshipInvites({
               ))
             )}
           </div>
+        </div>
+      </div>
+
+      <div className="card p-4">
+        <div className="text-sm font-black">Request access (parent/guardian)</div>
+        <p className="mt-1 text-sm text-slate-700">
+          If your student already has a profile, request access by entering the student’s email and the student profile ID. The student will approve or decline.
+        </p>
+
+        <div className="mt-4 grid sm:grid-cols-3 gap-3 items-end">
+          <div className="sm:col-span-2">
+            <label className="block text-sm font-semibold text-slate-700 mb-2">Student email</label>
+            <input
+              className="input w-full px-4 py-3 rounded-lg"
+              value={requestStudentEmail}
+              onChange={(e) => setRequestStudentEmail(e.target.value)}
+              placeholder="student@example.com"
+              disabled={saving}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-semibold text-slate-700 mb-2">Your role</label>
+            <select
+              className="input w-full px-4 py-3 rounded-lg"
+              value={requestRole}
+              onChange={(e) => setRequestRole(e.target.value as 'parent' | 'guardian')}
+              disabled={saving}
+            >
+              <option value="parent">Parent</option>
+              <option value="guardian">Guardian</option>
+            </select>
+          </div>
+        </div>
+
+        <div className="mt-3">
+          <label className="block text-sm font-semibold text-slate-700 mb-2">Student profile ID</label>
+          <input
+            className="input w-full px-4 py-3 rounded-lg"
+            value={requestStudentProfileId}
+            onChange={(e) => setRequestStudentProfileId(e.target.value)}
+            placeholder="Paste the student_profile_id (UUID)"
+            disabled={saving}
+          />
+          <p className="mt-2 text-xs text-slate-600">
+            The student can find this on <span className="font-semibold">/profile</span> and share it with you.
+          </p>
+        </div>
+
+        <div className="mt-4">
+          <button
+            type="button"
+            className="btn-secondary"
+            disabled={saving || !requestStudentEmail.trim() || !requestStudentProfileId.trim()}
+            onClick={createAccessRequest}
+          >
+            {saving ? 'Saving...' : 'Send access request'}
+          </button>
         </div>
       </div>
     </div>

--- a/apps/web/src/app/profile/ui/StudentProfileDetailsForm.tsx
+++ b/apps/web/src/app/profile/ui/StudentProfileDetailsForm.tsx
@@ -1,0 +1,148 @@
+'use client'
+
+import { useMemo, useState } from 'react'
+import { useRouter } from 'next/navigation'
+
+type School = { id: string; name: string; city: string | null; state: string | null }
+
+export default function StudentProfileDetailsForm({
+  studentProfileId,
+  initialFirstName,
+  initialLastName,
+  initialGraduationYear,
+  initialSchoolId,
+  schools,
+}: {
+  studentProfileId: string | null
+  initialFirstName: string | null
+  initialLastName: string | null
+  initialGraduationYear: number | null
+  initialSchoolId: string | null
+  schools: School[]
+}) {
+  const router = useRouter()
+  const [firstName, setFirstName] = useState(initialFirstName || '')
+  const [lastName, setLastName] = useState(initialLastName || '')
+  const [graduationYear, setGraduationYear] = useState<string>(initialGraduationYear ? String(initialGraduationYear) : '')
+  const [schoolQuery, setSchoolQuery] = useState('')
+  const [schoolId, setSchoolId] = useState<string | null>(initialSchoolId || null)
+  const [saving, setSaving] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+  const [success, setSuccess] = useState<string | null>(null)
+
+  const filteredSchools = useMemo(() => {
+    const q = schoolQuery.trim().toLowerCase()
+    if (!q) return schools.slice(0, 25)
+    return schools.filter((s) => s.name.toLowerCase().includes(q)).slice(0, 25)
+  }, [schoolQuery, schools])
+
+  async function save() {
+    if (!studentProfileId) return
+    setSaving(true)
+    setError(null)
+    setSuccess(null)
+    try {
+      const res = await fetch('/api/profile/student-profile', {
+        method: 'PATCH',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({
+          studentProfileId,
+          firstName: firstName || null,
+          lastName: lastName || null,
+          graduationYear: graduationYear.trim() ? Number(graduationYear) : null,
+          schoolId,
+        }),
+      })
+      const json = (await res.json().catch(() => null)) as { ok?: boolean; error?: string } | null
+      if (!res.ok || !json?.ok) {
+        setError(json?.error || 'Save failed')
+        return
+      }
+      setSuccess('Saved')
+      router.refresh()
+    } finally {
+      setSaving(false)
+    }
+  }
+
+  return (
+    <div className="card p-4">
+      <div className="text-sm font-black">Student profile details</div>
+      <p className="mt-1 text-sm text-slate-700">
+        Update the active student profile. (Students and linked parent/guardian/admin can edit core fields.)
+      </p>
+
+      <div className="mt-4 grid sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-semibold text-slate-700 mb-2">First name</label>
+          <input className="input w-full px-4 py-3 rounded-lg" value={firstName} onChange={(e) => setFirstName(e.target.value)} />
+        </div>
+        <div>
+          <label className="block text-sm font-semibold text-slate-700 mb-2">Last name</label>
+          <input className="input w-full px-4 py-3 rounded-lg" value={lastName} onChange={(e) => setLastName(e.target.value)} />
+        </div>
+      </div>
+
+      <div className="mt-4 grid sm:grid-cols-2 gap-4">
+        <div>
+          <label className="block text-sm font-semibold text-slate-700 mb-2">Graduation year</label>
+          <input
+            className="input w-full px-4 py-3 rounded-lg"
+            value={graduationYear}
+            onChange={(e) => setGraduationYear(e.target.value)}
+            placeholder="e.g. 2030"
+            inputMode="numeric"
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-semibold text-slate-700 mb-2">High school</label>
+          <input
+            className="input w-full px-4 py-3 rounded-lg"
+            value={schoolQuery}
+            onChange={(e) => setSchoolQuery(e.target.value)}
+            placeholder="Search"
+          />
+          <div className="mt-2 max-h-40 overflow-auto border border-slate-200 rounded-lg bg-white">
+            {filteredSchools.length === 0 ? (
+              <div className="p-3 text-sm text-slate-600">No matches</div>
+            ) : (
+              filteredSchools.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  className={`w-full text-left px-3 py-2 text-sm hover:bg-slate-50 ${
+                    schoolId === s.id ? 'bg-slate-50' : ''
+                  }`}
+                  onClick={() => {
+                    setSchoolId(s.id)
+                    setSchoolQuery(`${s.name}${s.city ? `, ${s.city}` : ''}${s.state ? `, ${s.state}` : ''}`)
+                  }}
+                >
+                  <div className="font-semibold text-slate-900">{s.name}</div>
+                  <div className="text-xs text-slate-600">{[s.city, s.state].filter(Boolean).join(', ')}</div>
+                </button>
+              ))
+            )}
+          </div>
+        </div>
+      </div>
+
+      {(error || success) && (
+        <div
+          className={`mt-4 text-sm text-center p-3 rounded-lg border ${
+            error ? 'text-red-700 bg-red-50 border-red-200' : 'text-emerald-800 bg-emerald-50 border-emerald-200'
+          }`}
+        >
+          {error || success}
+        </div>
+      )}
+
+      <div className="mt-4">
+        <button type="button" className="btn-primary" disabled={!studentProfileId || saving} onClick={save}>
+          {saving ? 'Saving...' : 'Save changes'}
+        </button>
+      </div>
+    </div>
+  )
+}
+

--- a/supabase/migrations/20260519120000_student_claim_invites.sql
+++ b/supabase/migrations/20260519120000_student_claim_invites.sql
@@ -1,0 +1,80 @@
+-- Student claim invite support (additive)
+-- Allows a parent/guardian/admin to invite a student to "claim" a student_profile.
+-- This is needed for the parent-led onboarding flow.
+
+do $$
+begin
+  -- Expand allowed invite roles to include 'student'
+  alter table public.student_profile_relationship_invites
+    drop constraint if exists student_profile_relationship_invites_relationship_role_check;
+
+  alter table public.student_profile_relationship_invites
+    add constraint student_profile_relationship_invites_relationship_role_check
+    check (relationship_role in ('parent','guardian','counselor','student'));
+exception
+  when undefined_table then
+    null;
+end $$;
+
+-- Security-definer RPC to accept a student claim invite, since updating student_profiles.student_user_id
+-- would otherwise be blocked by RLS for a brand-new student user.
+create or replace function public.accept_student_claim_invite(p_invite_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_invite record;
+  v_email text;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  v_email := lower(coalesce((auth.jwt() ->> 'email'), ''));
+
+  select *
+  into v_invite
+  from public.student_profile_relationship_invites
+  where id = p_invite_id
+    and status = 'pending'
+    and relationship_role = 'student'
+    and (
+      invited_user_id = auth.uid()
+      or (invited_user_id is null and invited_email is not null and lower(invited_email) = v_email)
+    );
+
+  if not found then
+    raise exception 'Invite not found or not eligible';
+  end if;
+
+  -- Mark invite accepted
+  update public.student_profile_relationship_invites
+  set status = 'accepted',
+      invited_user_id = auth.uid(),
+      updated_at = now()
+  where id = p_invite_id;
+
+  -- Attach the student auth user to the planning container if not already claimed
+  update public.student_profiles
+  set student_user_id = auth.uid(),
+      updated_at = now()
+  where id = v_invite.student_profile_id
+    and student_user_id is null;
+
+  -- Ensure the student is a member in family_relationships
+  insert into public.family_relationships (student_profile_id, user_id, role)
+  values (v_invite.student_profile_id, auth.uid(), 'student')
+  on conflict (student_profile_id, user_id) do nothing;
+end;
+$$;
+
+-- Allow authenticated callers to execute the RPC
+do $$
+begin
+  execute 'grant execute on function public.accept_student_claim_invite(uuid) to authenticated';
+exception
+  when undefined_function then null;
+end $$;
+

--- a/supabase/migrations/20260519133000_parent_access_requests.sql
+++ b/supabase/migrations/20260519133000_parent_access_requests.sql
@@ -1,0 +1,99 @@
+-- Parent/guardian access request support (additive)
+-- Allows a parent/guardian to request access to a student's profile by emailing the student.
+-- The student accepts/declines, and on accept we link the *requestor* (invite creator) to the student profile.
+
+do $$
+begin
+  -- Add a lightweight type discriminator so we can support both "supporter invite" (receiver becomes member)
+  -- and "access request" (creator becomes member after receiver approves).
+  alter table public.student_profile_relationship_invites
+    add column if not exists invite_type text not null default 'supporter_invite';
+
+  alter table public.student_profile_relationship_invites
+    drop constraint if exists student_profile_relationship_invites_invite_type_check;
+
+  alter table public.student_profile_relationship_invites
+    add constraint student_profile_relationship_invites_invite_type_check
+    check (invite_type in ('supporter_invite','access_request'));
+exception
+  when undefined_table then
+    null;
+end $$;
+
+-- RLS: allow any authenticated user to create an access request for a known student_profile_id.
+-- This is intentionally constrained:
+-- - creator must be the logged-in user
+-- - invite_type must be access_request
+-- - relationship_role must be parent/guardian (requesting access)
+do $$
+begin
+  if not exists (
+    select 1 from pg_policies
+    where schemaname = 'public'
+      and tablename = 'student_profile_relationship_invites'
+      and policyname = 'spri_insert_access_request'
+  ) then
+    create policy spri_insert_access_request
+    on public.student_profile_relationship_invites for insert
+    with check (
+      invite_type = 'access_request'
+      and created_by_user_id = auth.uid()
+      and relationship_role in ('parent','guardian')
+      and invited_email is not null
+      and student_profile_id is not null
+    );
+  end if;
+end $$;
+
+-- RPC: student approves a pending access request, linking the requestor to the student profile.
+create or replace function public.approve_access_request(p_invite_id uuid)
+returns void
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_invite record;
+  v_email text;
+begin
+  if auth.uid() is null then
+    raise exception 'Not authenticated';
+  end if;
+
+  v_email := lower(coalesce((auth.jwt() ->> 'email'), ''));
+
+  select *
+  into v_invite
+  from public.student_profile_relationship_invites
+  where id = p_invite_id
+    and status = 'pending'
+    and invite_type = 'access_request'
+    and (
+      invited_user_id = auth.uid()
+      or (invited_user_id is null and invited_email is not null and lower(invited_email) = v_email)
+    );
+
+  if not found then
+    raise exception 'Invite not found or not eligible';
+  end if;
+
+  -- Mark approved by the receiver (student) for auditability.
+  update public.student_profile_relationship_invites
+  set status = 'accepted',
+      invited_user_id = auth.uid(),
+      updated_at = now()
+  where id = p_invite_id;
+
+  -- Link the requestor (creator) to the student profile as the requested role.
+  insert into public.family_relationships (student_profile_id, user_id, role)
+  values (v_invite.student_profile_id, v_invite.created_by_user_id, v_invite.relationship_role)
+  on conflict (student_profile_id, user_id) do nothing;
+end;
+$$;
+
+do $$
+begin
+  execute 'grant execute on function public.approve_access_request(uuid) to authenticated';
+exception
+  when undefined_function then null;
+end $$;


### PR DESCRIPTION
Adds parent-led flow support: invite a student by email to claim a student profile.

Changes:
- Supabase migration adds relationship_role='student' and RPC accept_student_claim_invite
- Web profile UI adds 'Invite student to claim this profile'
- API supports relationshipRole='student' and uses RPC on accept

Manual step:
Run supabase/migrations/20260519120000_student_claim_invites.sql in Supabase SQL Editor.