### PR TITLE
feat(dashboard): active student card

### DIFF
--- a/apps/web/src/app/api/dashboard/summary/route.ts
+++ b/apps/web/src/app/api/dashboard/summary/route.ts
@@ -30,7 +30,7 @@ export async function GET() {
 
   const { data: studentProfile } = await supabase
     .from('student_profiles')
-    .select('id,graduation_year,grade_level')
+    .select('id,first_name,last_name,graduation_year,grade_level,schools(name)')
     .eq('id', studentProfileId)
     .maybeSingle()
 
@@ -105,6 +105,7 @@ export async function GET() {
   return ok({
     studentProfileId,
     viewerRole: (viewerProfile?.role as string | null) || null,
+    activeStudentProfile: studentProfile || null,
     gradeLevel,
     academicRecords: records || [],
     latestAcademicRecordAt,

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -6,6 +6,7 @@ import StatTile from '@/components/StatTile'
 import DocUpload from '@/components/DocUpload'
 import ReportCardVault from '@/components/ReportCardVault'
 import StudentSuccessChecklist from '@/components/StudentSuccessChecklist'
+import ActiveStudentCard from '@/components/ActiveStudentCard'
 import { useAuthSession } from '@/lib/use-auth-session'
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
@@ -23,6 +24,13 @@ type DashboardSummary = {
   ok: boolean
   studentProfileId: string | null
   viewerRole: string | null
+  activeStudentProfile?: {
+    id: string
+    first_name: string | null
+    last_name: string | null
+    graduation_year: number | null
+    schools?: { name: string | null } | null
+  } | null
   latestAcademicRecordAt: string | null
   checklist?: { done: number; total: number }
   tasks?: DashboardTask[]
@@ -105,6 +113,7 @@ export default function Dashboard() {
 
   const viewerRole = (summary?.viewerRole as string | null) || null
   const showParentActionCenter = viewerRole === 'parent' || viewerRole === 'guardian' || viewerRole === 'admin'
+  const showCounselorInfo = viewerRole === 'counselor'
 
   return (
     <div className="container-prose py-14">
@@ -114,6 +123,18 @@ export default function Dashboard() {
           <p className="text-slate-700 mt-2">Check in each grading period—track progress year-round.</p>
         </div>
       </div>
+
+      <ActiveStudentCard studentProfile={summary?.activeStudentProfile || null} />
+
+      {showCounselorInfo ? (
+        <div className="mb-6 rounded-xl border border-slate-200 bg-white p-4 text-sm text-slate-800">
+          <div className="font-semibold">Counselor access</div>
+          <div className="mt-1">
+            Counselors currently have read/support access only. Editing core profile fields and checklist completion is
+            reserved for the student and parent/guardian.
+          </div>
+        </div>
+      ) : null}
 
       {bootstrapError && (
         <div className="mb-6 rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">

--- a/apps/web/src/components/ActiveStudentCard.tsx
+++ b/apps/web/src/components/ActiveStudentCard.tsx
@@ -1,0 +1,55 @@
+'use client'
+
+import Link from 'next/link'
+import CopyTextButton from '@/components/CopyTextButton'
+
+type ActiveStudentProfile = {
+  id: string
+  first_name: string | null
+  last_name: string | null
+  graduation_year: number | null
+  schools?: { name: string | null } | null
+}
+
+export default function ActiveStudentCard({
+  studentProfile,
+}: {
+  studentProfile: ActiveStudentProfile | null
+}) {
+  if (!studentProfile) return null
+
+  const name =
+    [studentProfile.first_name, studentProfile.last_name].filter(Boolean).join(' ') || 'Student'
+
+  return (
+    <div className="card p-6 mb-8">
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <div className="badge">Active Student</div>
+          <h2 className="mt-2 text-xl font-black tracking-tight">{name}</h2>
+          <div className="mt-2 text-sm text-slate-700 space-y-1">
+            <div>
+              <span className="font-semibold">Graduation year:</span>{' '}
+              {studentProfile.graduation_year || '—'}
+            </div>
+            <div>
+              <span className="font-semibold">School:</span> {studentProfile.schools?.name || '—'}
+            </div>
+          </div>
+        </div>
+
+        <div className="shrink-0 flex flex-col gap-2">
+          <Link href="/profile" className="btn-secondary text-center">
+            Change
+          </Link>
+          <CopyTextButton text={studentProfile.id} label="Copy ID" />
+        </div>
+      </div>
+
+      <div className="mt-3 text-xs text-slate-600">
+        This selection controls which student’s dashboard, LifePath, uploads, and checklists you’re viewing.
+      </div>
+    </div>
+  )
+}
+

--- a/apps/web/src/components/CopyTextButton.tsx
+++ b/apps/web/src/components/CopyTextButton.tsx
@@ -1,0 +1,30 @@
+'use client'
+
+import { useState } from 'react'
+
+export default function CopyTextButton({
+  text,
+  label = 'Copy',
+}: {
+  text: string
+  label?: string
+}) {
+  const [copied, setCopied] = useState(false)
+
+  async function copy() {
+    try {
+      await navigator.clipboard.writeText(text)
+      setCopied(true)
+      window.setTimeout(() => setCopied(false), 1200)
+    } catch {
+      // ignore
+    }
+  }
+
+  return (
+    <button type="button" className="btn-secondary" onClick={copy} disabled={!text}>
+      {copied ? 'Copied' : label}
+    </button>
+  )
+}
+


### PR DESCRIPTION
Adds an Active Student card to /dashboard (name, school, grad year, copy student_profile_id, change link to /profile). Also adds counselor messaging and extends /api/dashboard/summary to return activeStudentProfile details.