### PR TITLE
fix(dashboard): counselor checklist read-only

### DIFF
--- a/apps/web/src/app/api/dashboard/tasks/route.ts
+++ b/apps/web/src/app/api/dashboard/tasks/route.ts
@@ -15,6 +15,15 @@ export async function PATCH(req: Request) {
 
   if (!session) return error('Not authenticated', 401)
 
+  // Counselors are read/support only; do not allow checklist mutation.
+  const { data: viewerProfile, error: viewerErr } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', session.user.id)
+    .maybeSingle()
+  if (viewerErr) return error(viewerErr.message)
+  if ((viewerProfile?.role as string | null) === 'counselor') return error('Forbidden', 403)
+
   const body = (await req.json().catch(() => null)) as
     | {
         taskId?: string
@@ -40,4 +49,3 @@ export async function PATCH(req: Request) {
   if (updateError) return error(updateError.message)
   return NextResponse.json({ ok: true, task: updated })
 }
-

--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -227,7 +227,11 @@ export default function Dashboard() {
       </div>
 
       <div className="mb-8">
-        <StudentSuccessChecklist tasks={summary?.tasks || []} onChanged={loadSummary} />
+        <StudentSuccessChecklist
+          tasks={summary?.tasks || []}
+          onChanged={loadSummary}
+          readOnly={viewerRole === 'counselor'}
+        />
       </div>
 
       <div className="grid sm:grid-cols-2 lg:grid-cols-4 gap-6">

--- a/apps/web/src/components/StudentSuccessChecklist.tsx
+++ b/apps/web/src/components/StudentSuccessChecklist.tsx
@@ -14,9 +14,11 @@ type Task = {
 export default function StudentSuccessChecklist({
   tasks,
   onChanged,
+  readOnly = false,
 }: {
   tasks: Task[]
   onChanged(): void
+  readOnly?: boolean
 }) {
   const [savingId, setSavingId] = useState<string | null>(null)
   const [error, setError] = useState<string | null>(null)
@@ -31,6 +33,7 @@ export default function StudentSuccessChecklist({
   }, [tasks])
 
   async function setStatus(taskId: string, status: Task['status']) {
+    if (readOnly) return
     setSavingId(taskId)
     setError(null)
     try {
@@ -92,27 +95,33 @@ export default function StudentSuccessChecklist({
                       {t.description ? <div className="mt-1 text-xs text-slate-700">{t.description}</div> : null}
                     </div>
 
-                    <div className="flex items-center gap-2 shrink-0">
-                      {t.status !== 'done' ? (
-                        <button
-                          type="button"
-                          className="btn-primary"
-                          disabled={savingId === t.id}
-                          onClick={() => setStatus(t.id, 'done')}
-                        >
-                          {savingId === t.id ? 'Saving...' : 'Mark done'}
-                        </button>
-                      ) : (
-                        <button
-                          type="button"
-                          className="btn-secondary"
-                          disabled={savingId === t.id}
-                          onClick={() => setStatus(t.id, 'not_started')}
-                        >
-                          {savingId === t.id ? 'Saving...' : 'Undo'}
-                        </button>
-                      )}
-                    </div>
+                    {!readOnly ? (
+                      <div className="flex items-center gap-2 shrink-0">
+                        {t.status !== 'done' ? (
+                          <button
+                            type="button"
+                            className="btn-primary"
+                            disabled={savingId === t.id}
+                            onClick={() => setStatus(t.id, 'done')}
+                          >
+                            {savingId === t.id ? 'Saving...' : 'Mark done'}
+                          </button>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn-secondary"
+                            disabled={savingId === t.id}
+                            onClick={() => setStatus(t.id, 'not_started')}
+                          >
+                            {savingId === t.id ? 'Saving...' : 'Undo'}
+                          </button>
+                        )}
+                      </div>
+                    ) : (
+                      <div className="shrink-0 text-xs text-slate-600 border border-slate-200 bg-slate-50 rounded-full px-2 py-1">
+                        Read-only
+                      </div>
+                    )}
                   </div>
                 ))}
               </div>
@@ -123,4 +132,3 @@ export default function StudentSuccessChecklist({
     </div>
   )
 }
-


### PR DESCRIPTION
Counselors are read/support only. This change:

- Hides checklist mutation buttons and shows a Read-only badge in StudentSuccessChecklist when viewerRole is counselor
- Adds a server-side guard in PATCH /api/dashboard/tasks returning 403 for counselors

Validation: npm run verify