### PR TITLE
feat(aura): active student header

### DIFF
--- a/apps/web/src/app/aura/lifepath/career/[id]/page.tsx
+++ b/apps/web/src/app/aura/lifepath/career/[id]/page.tsx
@@ -1,9 +1,12 @@
 import LifePathCareerDetail from '@/features/aura/lifepath/components/LifePathCareerDetail'
 import { CAREERS } from '@/features/aura/lifepath/data/careers'
 import { requireSessionProfile } from '@/lib/auth'
+import ActiveStudentHeader from '@/components/ActiveStudentHeader'
+import { getActiveStudentProfileSummary } from '@/lib/student-profile'
 
 export default async function LifePathCareerPage({ params }: { params: Promise<{ id: string }> }) {
-  await requireSessionProfile('/aura/lifepath/compare')
+  await requireSessionProfile('/aura/lifepath/career')
+  const studentProfile = await getActiveStudentProfileSummary()
   const { id } = await params
   const career = CAREERS.find((c) => c.id === id)
 
@@ -20,6 +23,7 @@ export default async function LifePathCareerPage({ params }: { params: Promise<{
 
   return (
     <section className="container-prose pt-10 pb-20">
+      <ActiveStudentHeader studentProfile={studentProfile} />
       <LifePathCareerDetail career={career} />
     </section>
   )

--- a/apps/web/src/app/aura/lifepath/compare/page.tsx
+++ b/apps/web/src/app/aura/lifepath/compare/page.tsx
@@ -1,10 +1,14 @@
 import LifePathCompareDashboard from '@/features/aura/lifepath/components/LifePathCompareDashboard'
 import { requireSessionProfile } from '@/lib/auth'
+import ActiveStudentHeader from '@/components/ActiveStudentHeader'
+import { getActiveStudentProfileSummary } from '@/lib/student-profile'
 
 export default async function LifePathComparePage() {
   await requireSessionProfile('/aura/lifepath/compare')
+  const studentProfile = await getActiveStudentProfileSummary()
   return (
     <section className="container-prose pt-10 pb-20">
+      <ActiveStudentHeader studentProfile={studentProfile} />
       <LifePathCompareDashboard />
     </section>
   )

--- a/apps/web/src/app/aura/lifepath/page.tsx
+++ b/apps/web/src/app/aura/lifepath/page.tsx
@@ -1,10 +1,14 @@
 import { requireSessionProfile } from '@/lib/auth'
 import LifePathDashboard from '@/features/aura/lifepath/components/LifePathDashboard'
+import ActiveStudentHeader from '@/components/ActiveStudentHeader'
+import { getActiveStudentProfileSummary } from '@/lib/student-profile'
 
 export default async function LifePathLandingPage() {
   await requireSessionProfile('/aura/lifepath')
+  const studentProfile = await getActiveStudentProfileSummary()
   return (
     <section className="container-prose pt-10 pb-20">
+      <ActiveStudentHeader studentProfile={studentProfile} />
       <LifePathDashboard />
     </section>
   )

--- a/apps/web/src/app/aura/lifepath/select/page.tsx
+++ b/apps/web/src/app/aura/lifepath/select/page.tsx
@@ -1,10 +1,14 @@
 import CareerSelectionGrid from '@/features/aura/lifepath/components/CareerSelectionGrid'
 import { requireSessionProfile } from '@/lib/auth'
+import ActiveStudentHeader from '@/components/ActiveStudentHeader'
+import { getActiveStudentProfileSummary } from '@/lib/student-profile'
 
 export default async function LifePathSelectPage() {
   await requireSessionProfile('/aura/lifepath/select')
+  const studentProfile = await getActiveStudentProfileSummary()
   return (
     <section className="container-prose pt-10 pb-20">
+      <ActiveStudentHeader studentProfile={studentProfile} />
       <CareerSelectionGrid />
     </section>
   )

--- a/apps/web/src/components/ActiveStudentHeader.tsx
+++ b/apps/web/src/components/ActiveStudentHeader.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link'
+import type { ActiveStudentProfileSummary } from '@/lib/student-profile'
+
+export default function ActiveStudentHeader({
+  studentProfile,
+}: {
+  studentProfile: ActiveStudentProfileSummary | null
+}) {
+  if (!studentProfile) return null
+
+  const name =
+    [studentProfile.first_name, studentProfile.last_name].filter(Boolean).join(' ') || 'Student'
+
+  return (
+    <div className="card p-4 mb-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="text-xs font-semibold text-slate-600">Active student</div>
+          <div className="mt-1 font-black truncate">{name}</div>
+          <div className="mt-1 text-xs text-slate-600">
+            {studentProfile.schools?.name || '—'}
+            {studentProfile.graduation_year ? ` • Class of ${studentProfile.graduation_year}` : ''}
+          </div>
+        </div>
+        <Link href="/profile" className="btn-secondary shrink-0">
+          Change
+        </Link>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/web/src/lib/student-profile.ts
+++ b/apps/web/src/lib/student-profile.ts
@@ -1,6 +1,13 @@
 import { createNextServerSupabaseClient, type UserRole } from '@mysryear/shared'
 
 type StudentProfileRow = { id: string; student_user_id: string | null }
+export type ActiveStudentProfileSummary = {
+  id: string
+  first_name: string | null
+  last_name: string | null
+  graduation_year: number | null
+  schools: { name: string | null } | null
+}
 
 export async function getActiveStudentProfileId(): Promise<string | null> {
   const supabase = await createNextServerSupabaseClient()
@@ -78,4 +85,23 @@ export async function setActiveStudentProfileId(studentProfileId: string | null)
     .from('profiles')
     .update({ active_student_profile_id: studentProfileId })
     .eq('id', session.user.id)
+}
+
+export async function getActiveStudentProfileSummary(): Promise<ActiveStudentProfileSummary | null> {
+  const supabase = await createNextServerSupabaseClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) return null
+
+  const id = await getActiveStudentProfileId()
+  if (!id) return null
+
+  const { data } = await supabase
+    .from('student_profiles')
+    .select('id,first_name,last_name,graduation_year,schools(name)')
+    .eq('id', id)
+    .maybeSingle()
+
+  return (data as unknown as ActiveStudentProfileSummary | null) || null
 }


### PR DESCRIPTION
Adds a compact Active Student header to A.U.R.A LifePath pages (lifepath landing, select, compare, career detail) so parents managing multiple students always know which profile they are viewing. Uses a new helper getActiveStudentProfileSummary().\n\nValidation: npm run verify