### PR TITLE
feat(ui): student-scoped active header layouts

### DIFF
--- a/apps/web/src/app/aura/layout.tsx
+++ b/apps/web/src/app/aura/layout.tsx
@@ -1,0 +1,11 @@
+import StudentScopedHeader from '@/components/StudentScopedHeader'
+import type { ReactNode } from 'react'
+
+export default async function AuraLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <StudentScopedHeader requirePath="/aura" />
+      {children}
+    </>
+  )
+}

--- a/apps/web/src/app/open-dashboard/layout.tsx
+++ b/apps/web/src/app/open-dashboard/layout.tsx
@@ -1,0 +1,11 @@
+import StudentScopedHeader from '@/components/StudentScopedHeader'
+import type { ReactNode } from 'react'
+
+export default async function OpenDashboardLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <StudentScopedHeader requirePath="/open-dashboard" />
+      {children}
+    </>
+  )
+}

--- a/apps/web/src/app/planner/layout.tsx
+++ b/apps/web/src/app/planner/layout.tsx
@@ -1,0 +1,11 @@
+import StudentScopedHeader from '@/components/StudentScopedHeader'
+import type { ReactNode } from 'react'
+
+export default async function PlannerLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <StudentScopedHeader requirePath="/planner" />
+      {children}
+    </>
+  )
+}

--- a/apps/web/src/components/ActiveStudentHeader.tsx
+++ b/apps/web/src/components/ActiveStudentHeader.tsx
@@ -1,0 +1,32 @@
+import Link from 'next/link'
+import type { ActiveStudentProfileSummary } from '@/lib/student-profile'
+
+export default function ActiveStudentHeader({
+  studentProfile,
+}: {
+  studentProfile: ActiveStudentProfileSummary | null
+}) {
+  if (!studentProfile) return null
+
+  const name =
+    [studentProfile.first_name, studentProfile.last_name].filter(Boolean).join(' ') || 'Student'
+
+  return (
+    <div className="card p-4 mb-6">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0">
+          <div className="text-xs font-semibold text-slate-600">Active student</div>
+          <div className="mt-1 font-black truncate">{name}</div>
+          <div className="mt-1 text-xs text-slate-600">
+            {studentProfile.schools?.name || '—'}
+            {studentProfile.graduation_year ? ` • Class of ${studentProfile.graduation_year}` : ''}
+          </div>
+        </div>
+        <Link href="/profile" className="btn-secondary shrink-0">
+          Change
+        </Link>
+      </div>
+    </div>
+  )
+}
+

--- a/apps/web/src/components/StudentScopedHeader.tsx
+++ b/apps/web/src/components/StudentScopedHeader.tsx
@@ -1,0 +1,14 @@
+import { requireSessionProfile } from '@/lib/auth'
+import { getActiveStudentProfileSummary } from '@/lib/student-profile'
+import ActiveStudentHeader from '@/components/ActiveStudentHeader'
+
+export default async function StudentScopedHeader({ requirePath }: { requirePath: string }) {
+  await requireSessionProfile(requirePath)
+  const studentProfile = await getActiveStudentProfileSummary()
+
+  return (
+    <div className="container-prose pt-10 -mb-6">
+      <ActiveStudentHeader studentProfile={studentProfile} />
+    </div>
+  )
+}

--- a/apps/web/src/lib/student-profile.ts
+++ b/apps/web/src/lib/student-profile.ts
@@ -1,6 +1,13 @@
 import { createNextServerSupabaseClient, type UserRole } from '@mysryear/shared'
 
 type StudentProfileRow = { id: string; student_user_id: string | null }
+export type ActiveStudentProfileSummary = {
+  id: string
+  first_name: string | null
+  last_name: string | null
+  graduation_year: number | null
+  schools: { name: string | null } | null
+}
 
 export async function getActiveStudentProfileId(): Promise<string | null> {
   const supabase = await createNextServerSupabaseClient()
@@ -78,4 +85,23 @@ export async function setActiveStudentProfileId(studentProfileId: string | null)
     .from('profiles')
     .update({ active_student_profile_id: studentProfileId })
     .eq('id', session.user.id)
+}
+
+export async function getActiveStudentProfileSummary(): Promise<ActiveStudentProfileSummary | null> {
+  const supabase = await createNextServerSupabaseClient()
+  const {
+    data: { session },
+  } = await supabase.auth.getSession()
+  if (!session) return null
+
+  const id = await getActiveStudentProfileId()
+  if (!id) return null
+
+  const { data } = await supabase
+    .from('student_profiles')
+    .select('id,first_name,last_name,graduation_year,schools(name)')
+    .eq('id', id)
+    .maybeSingle()
+
+  return (data as unknown as ActiveStudentProfileSummary | null) || null
 }


### PR DESCRIPTION
Standardizes Active Student context across student-scoped pages using Next.js layouts.

- Adds StudentScopedHeader (server) that fetches the active student profile summary and renders ActiveStudentHeader
- Adds layouts for /aura, /open-dashboard, and /planner to mount the header consistently
- Adds getActiveStudentProfileSummary() helper in lib/student-profile

Validation: npm run verify