### PR TITLE
feat(web): Test Prep + Essays/Resume Vault

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -10,6 +10,7 @@ import ActiveStudentCard from '@/components/ActiveStudentCard'
 import { useAuthSession } from '@/lib/use-auth-session'
 import { useEffect, useState } from 'react'
 import { useRouter } from 'next/navigation'
+import { BookOpenCheck, FileSignature } from 'lucide-react'
 
 type DashboardTask = {
   id: string
@@ -251,6 +252,18 @@ export default function Dashboard() {
           <CalendarClock className="w-8 h-8 text-brand-600 mb-4" />
           <h3 className="text-lg font-bold mb-2">Planner</h3>
           <p className="text-slate-600 text-sm">Senior year timeline and tasks</p>
+        </Link>
+
+        <Link href="/test-prep" className="card p-6 hover:shadow-lg transition">
+          <BookOpenCheck className="w-8 h-8 text-brand-600 mb-4" />
+          <h3 className="text-lg font-bold mb-2">Test Prep</h3>
+          <p className="text-slate-600 text-sm">Plan PSAT/SAT/ACT and track prep</p>
+        </Link>
+
+        <Link href="/vault" className="card p-6 hover:shadow-lg transition">
+          <FileSignature className="w-8 h-8 text-brand-600 mb-4" />
+          <h3 className="text-lg font-bold mb-2">Essays & Resume Vault</h3>
+          <p className="text-slate-600 text-sm">Store essays, resumes, and key documents</p>
         </Link>
 
         <Link href="/resources" className="card p-6 hover:shadow-lg transition">

--- a/apps/web/src/app/test-prep/page.tsx
+++ b/apps/web/src/app/test-prep/page.tsx
@@ -1,0 +1,49 @@
+import { requireSessionProfile } from '@/lib/auth'
+
+export default async function TestPrepPage() {
+  await requireSessionProfile('/test-prep')
+
+  return (
+    <section className="container-prose pt-10 pb-20 space-y-6">
+      <div className="card p-8">
+        <div className="badge">Test Prep</div>
+        <h1 className="mt-3 text-3xl sm:text-4xl font-black tracking-tight">Test Prep</h1>
+        <p className="mt-3 text-slate-700 max-w-2xl">
+          A simple hub to plan PSAT/SAT/ACT/ASVAB timelines and track what you’ve completed. We’ll
+          connect this to your grade level and LifePath goals next.
+        </p>
+      </div>
+
+      <div className="grid md:grid-cols-2 gap-6">
+        <div className="card p-6">
+          <div className="text-sm font-semibold text-slate-600">This Week</div>
+          <ul className="mt-3 list-disc ml-5 text-slate-700 space-y-2">
+            <li>Pick your target test(s) and date window.</li>
+            <li>Take one diagnostic practice set.</li>
+            <li>Set a weekly study rhythm (2–3 sessions).</li>
+          </ul>
+          <div className="mt-4 text-xs text-slate-500">
+            (MVP: static checklist. Next sprint: saved progress + reminders.)
+          </div>
+        </div>
+
+        <div className="card p-6">
+          <div className="text-sm font-semibold text-slate-600">Recommended Path</div>
+          <div className="mt-2 text-slate-700 text-sm space-y-2">
+            <div>
+              <span className="font-semibold">9th–10th:</span> light prep + build vocabulary/math
+              foundations.
+            </div>
+            <div>
+              <span className="font-semibold">11th:</span> choose test dates and run weekly practice.
+            </div>
+            <div>
+              <span className="font-semibold">12th:</span> finalize scores and focus scholarships/applications.
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  )
+}
+

--- a/apps/web/src/app/vault/page.tsx
+++ b/apps/web/src/app/vault/page.tsx
@@ -1,0 +1,34 @@
+import { requireSessionProfile } from '@/lib/auth'
+import VaultUpload from '@/components/VaultUpload'
+
+export default async function VaultPage() {
+  await requireSessionProfile('/vault')
+
+  return (
+    <section className="container-prose pt-10 pb-20 space-y-6">
+      <div className="card p-8">
+        <div className="badge">Vault</div>
+        <h1 className="mt-3 text-3xl sm:text-4xl font-black tracking-tight">Essays & Resume Vault</h1>
+        <p className="mt-3 text-slate-700 max-w-2xl">
+          Store and organize key documents for the active student profile—resumes, essays, cover
+          letters, recommendation materials, and more.
+        </p>
+      </div>
+
+      <VaultUpload
+        title="Upload a document"
+        description="These uploads are private to the active student profile. Use the dropdown to categorize each file."
+        defaultContext="vault_resume"
+        allowedContexts={[
+          { value: 'vault_resume', label: 'Resume' },
+          { value: 'vault_essay', label: 'Essay draft' },
+          { value: 'vault_cover_letter', label: 'Cover letter' },
+          { value: 'vault_recommendation', label: 'Recommendation materials' },
+          { value: 'vault_portfolio', label: 'Portfolio / work samples' },
+          { value: 'vault_other', label: 'Other' },
+        ]}
+      />
+    </section>
+  )
+}
+

--- a/apps/web/src/components/VaultUpload.tsx
+++ b/apps/web/src/components/VaultUpload.tsx
@@ -1,0 +1,199 @@
+'use client'
+
+import React, { useEffect, useMemo, useState } from 'react'
+import Link from 'next/link'
+import { usePathname } from 'next/navigation'
+import { useAuthSession } from '@/lib/use-auth-session'
+
+type UploadedFileRow = {
+  id: string
+  file_name: string
+  file_type: string | null
+  file_size: number | null
+  upload_context: string | null
+  created_at: string
+}
+
+export default function VaultUpload({
+  title,
+  description,
+  allowedContexts,
+  defaultContext,
+}: {
+  title: string
+  description?: string
+  allowedContexts: { value: string; label: string }[]
+  defaultContext: string
+}) {
+  const pathname = usePathname()
+  const { isAuthenticated } = useAuthSession()
+
+  const redirectHref = useMemo(() => {
+    const rt = pathname || '/dashboard'
+    return `/login?redirectTo=${encodeURIComponent(rt)}`
+  }, [pathname])
+
+  const [uploading, setUploading] = useState(false)
+  const [message, setMessage] = useState('')
+  const [files, setFiles] = useState<UploadedFileRow[]>([])
+  const [loadingList, setLoadingList] = useState(true)
+  const [context, setContext] = useState(defaultContext)
+
+  async function refreshList() {
+    setLoadingList(true)
+    setMessage('')
+    try {
+      const res = await fetch('/api/upload', { method: 'GET' })
+      const data = (await res.json()) as { ok?: boolean; files?: UploadedFileRow[]; error?: string }
+      if (data.ok && data.files) {
+        const allowed = new Set(allowedContexts.map((c) => c.value))
+        setFiles(data.files.filter((f) => (f.upload_context ? allowed.has(f.upload_context) : false)))
+      } else if (data.error) {
+        setMessage(`Error: ${data.error}`)
+      }
+    } finally {
+      setLoadingList(false)
+    }
+  }
+
+  useEffect(() => {
+    if (!isAuthenticated) {
+      setFiles([])
+      setLoadingList(false)
+      return
+    }
+    refreshList()
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isAuthenticated])
+
+  const handleUpload = async (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault()
+    if (!isAuthenticated) return
+    const form = e.currentTarget
+    const formData = new FormData(form)
+    formData.set('upload_context', context)
+
+    setUploading(true)
+    setMessage('')
+
+    try {
+      const res = await fetch('/api/upload', {
+        method: 'POST',
+        body: formData,
+      })
+
+      const data = (await res.json()) as { ok?: boolean; error?: string; file?: { file_name: string } }
+
+      if (data.ok) {
+        setMessage(`Uploaded: ${data.file?.file_name || 'file'}`)
+        form.reset()
+        await refreshList()
+      } else {
+        setMessage(`Error: ${data.error}`)
+      }
+    } catch {
+      setMessage('Upload failed')
+    } finally {
+      setUploading(false)
+    }
+  }
+
+  const handleDelete = async (id: string) => {
+    if (!isAuthenticated) return
+    setMessage('')
+    try {
+      const res = await fetch('/api/upload', {
+        method: 'DELETE',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify({ id }),
+      })
+      const data = (await res.json()) as { ok?: boolean; error?: string }
+      if (!data.ok) {
+        setMessage(`Error: ${data.error || 'Delete failed'}`)
+        return
+      }
+      await refreshList()
+    } catch {
+      setMessage('Delete failed')
+    }
+  }
+
+  return (
+    <div className="card p-6">
+      <h3 className="text-lg font-bold">{title}</h3>
+      {description ? <p className="mt-2 text-sm text-slate-700">{description}</p> : null}
+
+      {!isAuthenticated && (
+        <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+          <div className="font-semibold">Log in to upload files and save your progress.</div>
+          <div className="mt-2">
+            <Link href={redirectHref} className="btn-primary inline-flex">
+              Log In
+            </Link>
+          </div>
+        </div>
+      )}
+
+      <form onSubmit={handleUpload} className="mt-4 space-y-4">
+        <div>
+          <label className="block text-sm font-semibold text-slate-700 mb-2">Document type</label>
+          <select
+            className="input w-full px-4 py-3 rounded-lg"
+            value={context}
+            onChange={(e) => setContext(e.target.value)}
+            disabled={!isAuthenticated || uploading}
+          >
+            {allowedContexts.map((c) => (
+              <option key={c.value} value={c.value}>
+                {c.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        <input
+          type="file"
+          name="file"
+          className="block w-full text-sm text-slate-500 file:mr-4 file:py-2 file:px-4 file:rounded-lg file:border-0 file:text-sm file:font-semibold file:bg-brand-50 file:text-brand-700 hover:file:bg-brand-100"
+          disabled={uploading || !isAuthenticated}
+        />
+        <button type="submit" disabled={uploading || !isAuthenticated} className="btn-primary w-full">
+          {uploading ? 'Uploading...' : 'Upload'}
+        </button>
+      </form>
+
+      {message ? <p className="mt-3 text-sm">{message}</p> : null}
+
+      {isAuthenticated && loadingList ? <p className="mt-4 text-sm text-slate-600">Loading…</p> : null}
+
+      {isAuthenticated && !loadingList && files.length === 0 ? (
+        <div className="mt-4 rounded-xl border border-slate-200 bg-slate-50 p-4 text-sm text-slate-700">
+          No files uploaded yet for this vault.
+        </div>
+      ) : null}
+
+      {isAuthenticated && files.length > 0 ? (
+        <div className="mt-4">
+          <h4 className="text-sm font-semibold mb-2">Files</h4>
+          <ul className="text-sm text-slate-700 space-y-2">
+            {files.map((f) => (
+              <li key={f.id} className="flex items-center justify-between gap-3">
+                <div className="min-w-0">
+                  <div className="truncate font-medium">📄 {f.file_name}</div>
+                  <div className="text-xs text-slate-500">
+                    {f.upload_context || '—'}
+                    {f.file_type ? ` • ${f.file_type}` : ''}
+                  </div>
+                </div>
+                <button type="button" onClick={() => handleDelete(f.id)} className="btn-secondary">
+                  Delete
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+


### PR DESCRIPTION
Adds two missing web modules:

- /test-prep: Test Prep hub (MVP placeholder + guidance)
- /vault: Essays & Resume Vault using existing Supabase uploads, with categorization via upload_context
- Dashboard cards linking to both

Validation: npm run verify
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ebarlowjr2/mysryear/pull/36" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->